### PR TITLE
feat: add strategic classification system for org engagement tracking

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -821,6 +821,8 @@ app.get<{
           githubOrg: o.githubOrg,
           governanceModel: o.governanceModel,
           hasCommunityRepo: !!o.communityRepo,
+          strategicParticipation: o.strategicParticipation ?? null,
+          strategicLeadership: o.strategicLeadership ?? null,
           contributionCount: activity?.total ?? 0,
           trend: activity?.trend ?? [],
           totalTrend: activity?.totalTrend ?? [],

--- a/backend/src/modules/metrics/dashboard.ts
+++ b/backend/src/modules/metrics/dashboard.ts
@@ -241,7 +241,7 @@ export async function getDashboard(options: MetricsQueryOptions = {}): Promise<D
     buildTopProjects(),
     getLeadershipSummary(projectId, projectRepo, githubOrg),
     !projectId && !githubOrg
-      ? getOrgActivity({ days }).then(r => r.slice(0, 4))
+      ? getOrgActivity({ days })
       : Promise.resolve(undefined),
   ]);
 

--- a/backend/src/modules/metrics/org-activity.ts
+++ b/backend/src/modules/metrics/org-activity.ts
@@ -212,9 +212,12 @@ export async function getOrgActivity(options: MetricsQueryOptions = {}): Promise
       ? parseFloat(((counts.total / totalContribs) * 100).toFixed(1))
       : 0;
 
+    const orgConfig = getOrgConfig(org);
     results.push({
       org,
-      orgName: getOrgConfig(org)?.name ?? org,
+      orgName: orgConfig?.name ?? org,
+      strategicParticipation: orgConfig?.strategicParticipation ?? null,
+      strategicLeadership: orgConfig?.strategicLeadership ?? null,
       ...counts,
       trend: sparklineMap.get(org) ?? [],
       totalTrend: totalSparklineMap.get(org) ?? [],

--- a/backend/src/modules/metrics/types.ts
+++ b/backend/src/modules/metrics/types.ts
@@ -81,6 +81,8 @@ export interface DashboardSummary {
 export interface OrgActivityItem {
   org: string;
   orgName: string;
+  strategicParticipation?: string | null;
+  strategicLeadership?: string | null;
   total: number;
   commits: number;
   prs: number;

--- a/backend/src/shared/config/org-registry.ts
+++ b/backend/src/shared/config/org-registry.ts
@@ -58,6 +58,10 @@ export interface UpstreamOrgConfig {
   repoGovernanceOverride?: Record<string, 'owners' | 'codeowners' | 'none'>;
   /** Maps repo names to their owning working groups (only relevant for orgs with WGs) */
   repoToWorkingGroup?: Record<string, string[]>;
+  /** Strategic participation classification: evaluating_participation, sustaining_participation, increasing_participation */
+  strategicParticipation?: 'evaluating_participation' | 'sustaining_participation' | 'increasing_participation';
+  /** Strategic leadership classification: evaluating_leadership, sustaining_leadership, increasing_leadership */
+  strategicLeadership?: 'evaluating_leadership' | 'sustaining_leadership' | 'increasing_leadership';
 }
 
 // ── Registry ────────────────────────────────────────────────────────
@@ -67,6 +71,8 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
   {
     name: 'Kubeflow',
     githubOrg: 'kubeflow',
+    strategicParticipation: 'sustaining_participation',
+    strategicLeadership: 'sustaining_leadership',
     communityRepo: {
       repo: 'community',
       defaultBranch: 'master',
@@ -99,6 +105,8 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
   {
     name: 'KServe',
     githubOrg: 'kserve',
+    strategicParticipation: 'sustaining_participation',
+    strategicLeadership: 'sustaining_leadership',
     communityRepo: {
       repo: 'community',
       defaultBranch: 'main',
@@ -140,6 +148,8 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
   {
     name: 'vLLM',
     githubOrg: 'vllm-project',
+    strategicParticipation: 'increasing_participation',
+    strategicLeadership: 'increasing_leadership',
     governanceModel: 'codeowners',
   },
 
@@ -166,6 +176,8 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
   {
     name: 'Ray',
     githubOrg: 'ray-project',
+    strategicParticipation: 'sustaining_participation',
+    strategicLeadership: 'sustaining_leadership',
     governanceModel: 'codeowners',
   },
 
@@ -180,6 +192,8 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
   {
     name: 'Llama Stack',
     githubOrg: 'llamastack',
+    strategicParticipation: 'sustaining_participation',
+    strategicLeadership: 'sustaining_leadership',
     governanceModel: 'codeowners',
   },
 
@@ -201,6 +215,8 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
   {
     name: 'llm-d',
     githubOrg: 'llm-d',
+    strategicParticipation: 'increasing_participation',
+    strategicLeadership: 'sustaining_leadership',
     communityRepo: {
       repo: 'llm-d',
       defaultBranch: 'main',
@@ -239,6 +255,8 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
   {
     name: 'MLflow',
     githubOrg: 'mlflow',
+    strategicParticipation: 'increasing_participation',
+    strategicLeadership: 'increasing_leadership',
     communityRepo: {
       repo: 'mlflow',
       defaultBranch: 'master',
@@ -301,6 +319,8 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
   {
     name: 'PyTorch',
     githubOrg: 'pytorch',
+    strategicParticipation: 'increasing_participation',
+    strategicLeadership: 'increasing_leadership',
     communityRepo: {
       repo: 'pytorch',
       defaultBranch: 'main',
@@ -313,6 +333,32 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
       ],
     },
     governanceModel: 'codeowners',
+  },
+
+  // ─── DocLing ──────────────────────────────────
+  {
+    name: 'DocLing',
+    githubOrg: 'docling',
+    strategicParticipation: 'sustaining_participation',
+    strategicLeadership: 'sustaining_leadership',
+    governanceModel: 'codeowners',
+  },
+
+  // ─── Agentic AI Foundation ────────────────────
+  {
+    name: 'Agentic AI Foundation',
+    githubOrg: 'aaif',
+    strategicParticipation: 'evaluating_participation',
+    governanceModel: 'none',
+  },
+
+  // ─── Kagenti ────────────────────
+  {
+    name: 'Kagenti',
+    githubOrg: 'kagenti',
+    strategicParticipation: 'increasing_participation',
+    strategicLeadership: 'increasing_leadership',
+    governanceModel: 'none',
   },
 ];
 

--- a/backend/src/shared/database/migrate.ts
+++ b/backend/src/shared/database/migrate.ts
@@ -15,8 +15,14 @@ export async function runMigrations() {
   console.log('Running database migrations...');
 
   // Idempotent patches for databases that predate Drizzle migrations
+  // Only run if team_members table exists
   await client.unsafe(`
-    ALTER TABLE team_members ADD COLUMN IF NOT EXISTS source varchar(50) DEFAULT 'manual';
+    DO $$
+    BEGIN
+      IF EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'team_members') THEN
+        ALTER TABLE team_members ADD COLUMN IF NOT EXISTS source varchar(50) DEFAULT 'manual';
+      END IF;
+    END $$;
   `);
 
   await migrate(db, {


### PR DESCRIPTION
## Summary
- Add strategic participation and leadership classification to organization registry
- Include strategic classifications in API responses (/api/orgs, /api/metrics/org-activity)
- Organizations can now be classified across two dimensions:
  - Participation: evaluating, sustaining, or increasing participation levels
  - Leadership: evaluating, sustaining, or increasing leadership positions

## Test plan
- [ ] Verify API responses include strategic classification fields
- [ ] Check that org-registry updates are reflected in dashboard
- [ ] Confirm database migration runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)