### PR TITLE
feat: add Claude AI code review workflow

### DIFF
--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,0 +1,15 @@
+Review a GitHub pull request.
+
+## Arguments
+
+This command accepts a PR number as its argument: `/pr-review <PR_NUMBER>`
+
+## Steps
+
+1. Fetch the PR diff using `gh pr diff $ARGUMENTS`
+2. Fetch the PR description using `gh pr view $ARGUMENTS`
+3. Read `.github/instructions/review.instructions.md` and apply its review criteria to the diff.
+4. Read any files from the repo that you need additional context on to complete the review.
+5. Print a review summary to the terminal with:
+   - An overall assessment
+   - Specific issues found, organized by file, with line references

--- a/.github/instructions/review.instructions.md
+++ b/.github/instructions/review.instructions.md
@@ -1,0 +1,67 @@
+# Code Review Criteria
+
+This file defines the review criteria for all code reviews — automated (CI) and
+manual (local `/pr-review` command). All reviewers (human or AI) should apply
+these criteria consistently.
+
+## Review checklist
+
+1. **Security** — OWASP top 10 vulnerabilities: injection (SQL, command, XSS),
+   broken auth, sensitive data exposure, insecure deserialization. Pay special
+   attention to:
+   - User input handling and API route boundaries
+   - Fastify request validation (Zod schemas must validate all inputs)
+   - Octokit/GitHub API token handling — never log or expose tokens
+   - Secrets in config — must come from env vars, never hardcoded
+
+2. **Correctness** — Bugs, logic errors, off-by-one errors, unhandled edge
+   cases, race conditions, null/undefined access, and incorrect assumptions
+   about data shape or API behavior. Verify TypeScript types match runtime
+   reality — no unsafe `as` casts or `any` types without justification.
+
+3. **Code quality** — Readability, maintainability, appropriate abstraction
+   level. Flag unnecessary complexity, dead code, or misleading names. Prefer
+   clarity over cleverness.
+
+4. **Project conventions**:
+   - ESM (`import`/`export`) throughout — both backend and frontend
+   - TypeScript strict mode — no `!` non-null assertions, explicit null guards
+   - Backend logging via `winston` logger — never `console.log`
+   - Drizzle ORM for database queries — no raw SQL unless justified
+   - Zod for runtime validation of API inputs
+   - React functional components with hooks — no class components
+   - Tailwind CSS for styling — no CSS modules or inline styles
+   - Test coverage for changed logic (Vitest)
+
+5. **Performance**:
+   - Frontend: unnecessary re-renders (missing `useMemo`/`useCallback`),
+     missing React Query cache keys, unbounded data fetching
+   - Backend: N+1 queries, missing database indexes for new query patterns,
+     unbounded result sets without pagination
+   - Workers: BullMQ jobs must handle failures gracefully and not retry
+     indefinitely — check `attempts` and `backoff` config
+   - Memory leaks: event listeners, timers, subscriptions not cleaned up
+
+6. **Database**:
+   - Drizzle schema changes in `schema.ts` must have a corresponding migration
+     (`npm run db:generate`)
+   - Verify queries use proper indexes — check for full table scans on large
+     tables (contributions, collection_jobs)
+   - Transactions for multi-table writes
+   - Foreign key cascades configured correctly
+
+7. **API & integration**:
+   - Octokit calls must use the throttling plugin — never raw `fetch` to
+     GitHub API
+   - WebSocket handlers (`@fastify/websocket`) must clean up on disconnect
+   - Cron jobs (`node-cron`) must be idempotent — safe to run if triggered
+     twice
+
+## Review tone
+
+- Be concise. Focus on actionable feedback.
+- Don't nitpick style unless it impacts readability.
+- Only flag issues you're confident about. If something is ambiguous or
+  subjective, frame it as a suggestion, not a blocker.
+- Don't comment on files outside the scope of the PR unless they're directly
+  affected (e.g., a missing import).

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,350 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    # NOTE: No paths-ignore here. "Claude Review" is a required status check,
+    # so the workflow must always run to report a result. Path filtering is
+    # handled inside the job via the "Check for reviewable changes" step.
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+concurrency:
+  group: claude-review-${{ github.event_name }}-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  # Full review with autofix — runs for same-repo PRs only (trusted code)
+  claude-review:
+    name: Claude Review
+    timeout-minutes: 20
+    if: |
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.pull_request.draft != true &&
+       github.actor != 'github-actions[bot]') ||
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       contains(github.event.comment.body, '@claude') &&
+       github.event.comment.author_association != 'NONE' &&
+       github.event.comment.author_association != 'FIRST_TIMER' &&
+       github.event.comment.author_association != 'FIRST_TIME_CONTRIBUTOR') ||
+      (github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for reviewable changes
+        id: check-paths
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "needs_review=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+            --paginate --jq '.[].filename')
+
+          needs_review=false
+          while IFS= read -r file; do
+            case "$file" in
+              deploy/openshift/overlays/*/kustomization.yaml) ;;
+              docs/*) ;;
+              *.md) ;;
+              package-lock.json|backend/package-lock.json|frontend/package-lock.json) ;;
+              .github/workflows/*) ;;
+              *)
+                needs_review=true
+                break
+                ;;
+            esac
+          done <<< "$CHANGED_FILES"
+
+          echo "needs_review=$needs_review" >> "$GITHUB_OUTPUT"
+          if [ "$needs_review" = "false" ]; then
+            echo "All changed files match ignore patterns — skipping review"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Reject fork PRs on issue_comment trigger
+        id: fork-guard
+        if: steps.check-paths.outputs.needs_review == 'true' && github.event_name == 'issue_comment'
+        run: |
+          IS_FORK=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }} \
+            --jq '.head.repo.full_name != .base.repo.full_name')
+
+          if [ "$IS_FORK" = "true" ]; then
+            echo "is_fork=true" >> "$GITHUB_OUTPUT"
+            gh pr comment "${{ github.event.issue.number }}" \
+              --repo "${{ github.repository }}" \
+              --body "Autofix review via \`@claude\` is not available on fork PRs for security reasons. A read-only review runs automatically when the PR is opened."
+            echo "::warning::Skipping autofix review — fork PR detected on issue_comment trigger"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout code
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install backend dependencies
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        run: npm ci
+        working-directory: backend
+
+      - name: Install frontend dependencies
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        run: npm ci
+        working-directory: frontend
+
+      - name: Configure git identity
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        run: |
+          git config user.name "claude-code-review[bot]"
+          git config user.email "claude-code-review[bot]@users.noreply.github.com"
+
+      - name: Authenticate to Google Cloud
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Claude Code Review
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        continue-on-error: true
+        with:
+          use_vertex: "true"
+          track_progress: true
+          display_report: "true"
+          include_fix_links: "true"
+          claude_args: '--model claude-opus-4-6 --max-turns 15 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr checkout:*),Bash(git add:*),Bash(git commit:*),Bash(git push origin:*),Bash(git diff:*),Bash(git status:*),Bash(cd backend && npm test:*),Bash(cd backend && npm run lint:*),Bash(cd backend && npm run type-check:*),Bash(cd frontend && npm run build:*),Bash(cd frontend && npm run lint:*),Read,Glob,Grep,Edit,Write"'
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            You are reviewing a pull request for **Upstream Pulse**, a TypeScript
+            monorepo with separate `backend/` (Fastify + Drizzle) and `frontend/`
+            (React + Vite) directories, each with their own `package.json`.
+
+            Your job is to:
+
+            1. **Determine PR context**:
+               - If no PR number is available (e.g., workflow_dispatch without context),
+                 post a comment explaining that no PR was found and exit.
+               - Run `gh pr checkout <PR_NUMBER>` to switch to the PR branch.
+
+            2. **Review** the PR diff. Read `.github/instructions/review.instructions.md`
+               for the full review checklist. Apply all criteria from that file.
+               Also read `CLAUDE.md`, `backend/CLAUDE.md`, and `frontend/CLAUDE.md`
+               for project conventions.
+
+            3. **Fix** any issues you find by editing the files directly:
+               - Use Edit/Write tools to modify the source files
+               - Fix all issues you're confident about: bugs, style, security, performance
+               - After making all fixes, validate based on which directories changed:
+                 - Backend changes: `cd backend && npm run type-check && npm test && npm run lint`
+                 - Frontend changes: `cd frontend && npm run build && npm run lint`
+               - If tests, type-check, or lint fail due to your changes, fix the issues
+                 or revert your changes to that file
+               - Only commit and push if you actually made changes and validation passes:
+                 ```
+                 git add -u
+                 git diff --cached --quiet || git commit -m "fix: Claude code review autofix
+
+                 <concise summary of changes>"
+                 git push origin HEAD
+                 ```
+
+            4. **Report** your findings:
+               - Use inline comments for issues you found (whether or not you fixed them)
+               - Post a top-level PR comment summarizing:
+                 - Issues found and fixed (with brief descriptions)
+                 - Issues found but NOT fixed (with explanations of why)
+                 - If no issues were found, say so briefly
+               - NOTE: CI will NOT automatically run on your autofix commit. Mention
+                 this in your summary so the PR author knows to re-run CI if needed.
+
+            5. **Set review verdict**: After completing your review, write a result file
+               to signal whether the PR should be blocked:
+               ```
+               echo "PASS" > .claude-review-result    # No blocking issues remain
+               echo "FAIL" > .claude-review-result    # Critical unfixed issues
+               ```
+               Use **FAIL** only for issues you could NOT fix that are: security
+               vulnerabilities, clear bugs that will cause runtime errors, or breaking
+               changes. If you found issues but fixed them all, use PASS.
+               Use **PASS** for: clean code, minor suggestions, style nits, or when
+               all issues were fixed by your autofix commit.
+               Always write this file as your very last action.
+
+            **Important rules:**
+            - Never force push. Only push to the current PR branch via `git push origin HEAD`.
+            - Use `git add -u` (not `git add -A`) to avoid staging untracked files.
+            - Be concise. Focus on actionable feedback. Don't nitpick style unless
+              it impacts readability.
+            - Only fix things you're confident about. If a fix is ambiguous or
+              subjective, comment instead of changing code.
+            - Do not modify files outside the scope of the PR unless necessary to
+              fix an issue (e.g., a missing import in another file).
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
+          CLOUD_ML_REGION: "us-east5"
+
+      - name: Check review result
+        if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
+        run: |
+          if [ "${{ steps.claude-review.outcome }}" = "failure" ]; then
+            echo "::warning::Claude review action failed (infrastructure issue) — not blocking PR"
+            exit 0
+          fi
+
+          if [ -f .claude-review-result ]; then
+            RESULT=$(tr -d '[:space:]' < .claude-review-result)
+            if [ "$RESULT" = "FAIL" ]; then
+              echo "::error::Claude review found critical issues that must be addressed before merging"
+              exit 1
+            fi
+          fi
+
+          echo "Claude review passed"
+
+  # Read-only review for fork PRs — never executes fork code
+  claude-review-fork:
+    name: Claude Review (Fork)
+    timeout-minutes: 20
+    if: |
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      github.event.pull_request.draft != true &&
+      github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for reviewable changes
+        id: check-paths
+        run: |
+          CHANGED_FILES=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+            --paginate --jq '.[].filename')
+
+          needs_review=false
+          while IFS= read -r file; do
+            case "$file" in
+              deploy/openshift/overlays/*/kustomization.yaml) ;;
+              docs/*) ;;
+              *.md) ;;
+              package-lock.json|backend/package-lock.json|frontend/package-lock.json) ;;
+              .github/workflows/*) ;;
+              *)
+                needs_review=true
+                break
+                ;;
+            esac
+          done <<< "$CHANGED_FILES"
+
+          echo "needs_review=$needs_review" >> "$GITHUB_OUTPUT"
+          if [ "$needs_review" = "false" ]; then
+            echo "All changed files match ignore patterns — skipping review"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout base branch
+        if: steps.check-paths.outputs.needs_review == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+
+      - name: Setup fork PR branch for action
+        if: steps.check-paths.outputs.needs_review == 'true'
+        id: fork-setup
+        run: |
+          echo "Fork PR #${PR_NUM} detected (branch: ${HEAD_REF})"
+
+          SAFE_BRANCH="claude-review/fork-pr-${PR_NUM}"
+
+          git fetch origin "refs/pull/${PR_NUM}/head"
+          git push origin "FETCH_HEAD:refs/heads/${SAFE_BRANCH}"
+
+          echo "fork_branch=${SAFE_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "Pushed fork PR head to origin/${SAFE_BRANCH}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+
+      - name: Authenticate to Google Cloud
+        if: steps.check-paths.outputs.needs_review == 'true'
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Claude Code Review (Read-Only)
+        if: steps.check-paths.outputs.needs_review == 'true'
+        uses: anthropics/claude-code-action@v1
+        continue-on-error: true
+        with:
+          use_vertex: "true"
+          track_progress: true
+          display_report: "true"
+          include_fix_links: "true"
+          claude_args: '--model claude-opus-4-6 --max-turns 10 --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"'
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are reviewing a **fork pull request** for Upstream Pulse. This is a
+            READ-ONLY review. You must NEVER execute any code from the PR (no npm test,
+            npm run, node, or any other command that runs PR code). You do NOT have
+            tools to edit files, commit, or push — only read and comment.
+
+            1. Run `gh pr diff ${{ github.event.pull_request.number }}` to get the
+               full diff of the PR.
+
+            2. **Review** the diff. Read `.github/instructions/review.instructions.md`
+               for the full review checklist. Apply all criteria from that file.
+
+            3. **Report** your findings:
+               - Use inline comments for specific issues in the diff
+               - Post a top-level PR comment summarizing:
+                 - Issues found (with brief descriptions and suggestions)
+                 - If no issues were found, say so briefly
+               - Note that this was a read-only review (fork PR) and no autofixes
+                 were applied
+
+            **Important rules:**
+            - This is a FORK PR. Do NOT run any commands that execute PR code.
+            - Do NOT attempt to check out the PR branch.
+            - Use `gh pr diff` and `Read` to understand the changes.
+            - Be concise. Focus on actionable feedback.
+        env:
+          ANTHROPIC_VERTEX_PROJECT_ID: "itpc-gcp-ai-eng-claude"
+          CLOUD_ML_REGION: "us-east5"
+
+      - name: Cleanup fork PR branch
+        if: always() && steps.fork-setup.outputs.fork_branch
+        run: |
+          echo "Cleaning up temporary branch: ${{ steps.fork-setup.outputs.fork_branch }}"
+          git push origin --delete "${{ steps.fork-setup.outputs.fork_branch }}" || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,89 @@
+# Upstream Pulse
+
+Automated upstream open-source contribution tracking and insights dashboard.
+
+## Repository Structure
+
+TypeScript monorepo with separate `backend/` and `frontend/` directories, each
+with their own `package.json`. No workspace manager — install dependencies in
+each directory independently.
+
+```
+backend/          # Fastify API + BullMQ workers (TypeScript, ESM)
+frontend/         # React SPA (Vite, TypeScript, Tailwind)
+deploy/           # OpenShift manifests (kustomize base + overlays)
+docs/             # Project documentation
+```
+
+## Commands
+
+```bash
+# Install
+cd backend && npm install
+cd frontend && npm install
+
+# Dev (starts Postgres, Redis, API server, and Vite dev server)
+npm run dev
+
+# Test (backend only — Vitest)
+cd backend && npm test
+
+# Type check
+cd backend && npm run type-check
+cd frontend && npm run type-check
+
+# Lint
+cd backend && npm run lint
+cd frontend && npm run lint
+
+# Build
+cd backend && npm run build          # tsc
+cd frontend && npm run build         # tsc && vite build
+
+# Database
+cd backend && npm run db:migrate     # apply Drizzle migrations
+cd backend && npm run db:generate    # generate migration from schema changes
+cd backend && npm run db:studio      # Drizzle Studio GUI
+```
+
+## Architecture
+
+- **Backend**: Fastify 4, PostgreSQL via Drizzle ORM, Redis + BullMQ for async
+  job processing, Winston for logging
+- **Frontend**: React 18, Vite, TanStack React Query, React Router, Recharts,
+  Tailwind CSS
+- **Infra**: Docker Compose for local dev (Postgres + Redis), OpenShift for
+  production, ArgoCD for GitOps deploys
+
+## Key Patterns
+
+- ESM (`import`/`export`) throughout — both backend and frontend
+- TypeScript strict mode — no `any`, no `!` non-null assertions
+- Backend logging via `winston` logger — never `console.log`
+- Zod for runtime validation of API inputs
+- Drizzle ORM for all database access — no raw SQL unless justified
+- BullMQ workers run in a separate process (`backend/src/worker.ts`)
+- Org registry (`backend/src/shared/config/org-registry.ts`) defines tracked
+  upstream projects — adding a project = adding an entry there
+
+## Code Review
+
+Review criteria are centralized in
+[`.github/instructions/review.instructions.md`](.github/instructions/review.instructions.md).
+This file is used by the CI review workflow, the `/pr-review` slash command,
+and GitHub Copilot code review.
+
+## CI/CD
+
+- **`ci.yml`** — Runs on PRs: backend type-check + tests (with Postgres
+  service), frontend build
+- **`build-and-push.yml`** — On push to `main`/`preprod`: builds Docker
+  images, pushes to Quay.io, updates kustomize overlay image tags
+- **`claude-review.yml`** — Automated AI code review on every PR
+
+## Repo Secrets
+
+| Secret | Purpose |
+|--------|---------|
+| `QUAY_ROBOT_USERNAME` / `QUAY_ROBOT_TOKEN` | Quay.io image push |
+| `GCP_SA_KEY` | GCP service account JSON key for Vertex AI (Claude review) |

--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -1,0 +1,72 @@
+# Backend
+
+Fastify 4 API server with BullMQ async job workers.
+
+## Stack
+
+- **Runtime**: Node 20, TypeScript, ESM
+- **Framework**: Fastify 4 with `@fastify/cors`, `@fastify/websocket`
+- **Database**: PostgreSQL 16 via Drizzle ORM (`postgres` driver)
+- **Queue**: Redis + BullMQ for background jobs
+- **Logging**: Winston (never use `console.log`)
+- **Validation**: Zod for request schemas
+- **GitHub API**: `@octokit/rest` with `@octokit/plugin-throttling`
+- **Testing**: Vitest
+
+## Project Layout
+
+```
+src/
+  app.ts                    # Fastify server, route registration, startup
+  worker.ts                 # BullMQ worker process (runs separately)
+  shared/
+    config/                 # App config, org-registry
+    database/
+      client.ts             # Drizzle + postgres client
+      schema.ts             # Drizzle table definitions
+      migrate.ts            # Migration runner
+      migrations/           # SQL migration files (drizzle-kit generate)
+    middleware/              # Fastify hooks (identity, admin-guard)
+    types/                  # Shared TypeScript types
+    utils/                  # Logger, helpers
+  modules/
+    api/routes/             # Fastify route handlers
+    collection/             # GitHub data collection logic
+    metrics/                # Dashboard metrics, aggregation
+    insights/               # AI-powered insights (Gemini)
+    identity/               # Team member identity resolution
+  jobs/
+    scheduler.ts            # Cron-based job scheduling (node-cron)
+    workers/                # BullMQ worker implementations
+      collection-worker.ts  # GitHub contribution data collection
+      governance-worker.ts  # Governance file parsing
+      leadership-worker.ts  # Leadership/maintainer extraction
+      team-sync-worker.ts   # GitHub org member sync
+  scripts/                  # One-off scripts (seed, backfill)
+  test/                     # Test helpers, fixtures
+```
+
+## Database Conventions
+
+- All tables defined in `src/shared/database/schema.ts`
+- Schema changes: modify `schema.ts`, then `npm run db:generate` to create
+  migration, then `npm run db:migrate` to apply
+- Use Drizzle query builder — avoid raw SQL
+- UUIDs for primary keys (`uuid('id').defaultRandom().primaryKey()`)
+- Timestamps: `created_at`, `updated_at` with `defaultNow()`
+- Indexes defined in table config function
+
+## API Conventions
+
+- Routes registered in `app.ts` or via `modules/api/routes/`
+- Use Fastify's `request.log` or the shared `logger` — never `console.log`
+- Validate inputs with Zod schemas
+- Return consistent JSON shapes: `{ data }` for success, throw Fastify errors
+  for failures
+
+## Worker Conventions
+
+- Workers defined in `src/jobs/workers/`, registered in `src/worker.ts`
+- Each worker processes a specific BullMQ queue
+- Scheduler (`src/jobs/scheduler.ts`) uses `node-cron` to enqueue periodic jobs
+- Workers must handle failures gracefully and log errors via Winston

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -1,0 +1,48 @@
+# Frontend
+
+React 18 SPA dashboard with Vite bundler.
+
+## Stack
+
+- **Framework**: React 18 with functional components and hooks
+- **Bundler**: Vite 5
+- **Routing**: React Router v6
+- **Data fetching**: TanStack React Query v5
+- **Charts**: Recharts
+- **Styling**: Tailwind CSS 3, `clsx`, `tailwind-merge`, `class-variance-authority`
+- **Icons**: Lucide React
+- **Validation**: Zod (shared with backend)
+
+## Project Layout
+
+```
+src/
+  pages/                  # Route-level components
+    Dashboard.tsx         # Main dashboard view
+    Organizations.tsx     # Org listing
+    OrganizationDetail.tsx
+    Projects.tsx          # Project listing
+    ProjectDetail.tsx
+    Contributors.tsx      # Contributor directory
+    MyContributions.tsx   # Current user's contributions
+    SystemStatus.tsx      # Admin system health
+    About.tsx
+  components/
+    layout/               # App shell, navigation, sidebar
+    dashboard/            # Dashboard-specific components (StatCard, charts)
+    admin/                # Admin-only components
+    common/               # Shared components
+    ui/                   # Primitive UI components (buttons, cards, inputs)
+  context/                # React context providers
+  lib/
+    api.ts                # API client (fetch wrapper for backend)
+```
+
+## Conventions
+
+- Functional components only — no class components
+- Use React Query for all server state — no manual `useEffect` + `fetch`
+- Keep components focused: extract hooks for complex logic
+- Tailwind utility classes for styling — no CSS modules or styled-components
+- `clsx()` and `tailwind-merge` for conditional class composition
+- Pages are lazy-loaded via React Router


### PR DESCRIPTION
## Summary

- Add automated Claude code review via `anthropics/claude-code-action@v1` using Vertex AI
- Same-repo PRs get full review with autofix (edits code, runs tests, commits fixes)
- Fork PRs get read-only review (reads diff, posts comments, never executes fork code)
- Add hierarchical `CLAUDE.md` project context (root + backend + frontend) so Claude understands the monorepo structure
- Add project-specific review checklist covering security, correctness, Drizzle migrations, BullMQ workers, Octokit throttling, and more
- Add `/pr-review` Claude Code slash command for local reviews

## Files added

| File | Purpose |
|------|---------|
| `.github/workflows/claude-review.yml` | CI workflow (autofix + fork read-only) |
| `.github/instructions/review.instructions.md` | Shared review checklist (7 categories) |
| `CLAUDE.md` | Root project context |
| `backend/CLAUDE.md` | Backend conventions (Fastify, Drizzle, BullMQ) |
| `frontend/CLAUDE.md` | Frontend conventions (React, Vite, Tailwind) |
| `.claude/commands/pr-review.md` | Local `/pr-review` slash command |

## Prerequisites

- `GCP_SA_KEY` secret must be configured in repo settings (Vertex AI auth)

## Test plan

- [ ] Verify `GCP_SA_KEY` secret is set in repo settings
- [ ] Merge this PR and open a test PR with a code change to confirm the review triggers
- [ ] Test `@claude` mention in a PR comment to verify interactive mode