### PR TITLE
test: verify Claude review workflow

### DIFF
--- a/backend/src/shared/utils/logger.ts
+++ b/backend/src/shared/utils/logger.ts
@@ -26,7 +26,7 @@ export const logger = winston.createLogger({
     timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
     logFormat
   ),
-  defaultMeta: { service: 'upstream-pulse' },
+  defaultMeta: { service: 'upstream-pulse', version: '1.0.0' },
   transports: [
     new winston.transports.Console({
       format: combine(


### PR DESCRIPTION
Small test change to verify the Claude review workflow triggers correctly.

Adds `version` to the Winston logger default metadata.