### PR TITLE
feat: add contributor home page with three-tab layout, heatmap, action queue, and activity table

### DIFF
--- a/backend/src/jobs/workers/collection-worker.ts
+++ b/backend/src/jobs/workers/collection-worker.ts
@@ -35,7 +35,16 @@ async function resolveAndStore(
   for (const record of records) {
     try {
       const identity = identities.get(record.author || 'unknown');
-      const inserted = await db.insert(contributions).values({
+      const updateFields: Record<string, unknown> = {};
+      if (record.linesAdded != null) updateFields.linesAdded = record.linesAdded;
+      if (record.linesDeleted != null) updateFields.linesDeleted = record.linesDeleted;
+      if (record.filesChanged != null) updateFields.filesChanged = record.filesChanged;
+      if (record.isMerged != null) updateFields.isMerged = record.isMerged;
+      if (record.metadata?.url) updateFields.githubUrl = record.metadata.url;
+
+      const hasUpdates = Object.keys(updateFields).length > 0;
+
+      const query = db.insert(contributions).values({
         projectId,
         teamMemberId: identity?.teamMember?.id,
         contributionType: record.type,
@@ -47,7 +56,15 @@ async function resolveAndStore(
         filesChanged: record.filesChanged,
         isMerged: record.isMerged,
         metadata: record.metadata,
-      }).onConflictDoNothing().returning({ id: contributions.id });
+      });
+
+      const inserted = hasUpdates
+        ? await query.onConflictDoUpdate({
+            target: [contributions.projectId, contributions.contributionType, contributions.githubId],
+            set: updateFields,
+          }).returning({ id: contributions.id })
+        : await query.onConflictDoNothing().returning({ id: contributions.id });
+
       if (inserted.length > 0) processed++;
     } catch (error) {
       errors++;

--- a/backend/src/modules/api/routes/metrics.ts
+++ b/backend/src/modules/api/routes/metrics.ts
@@ -13,8 +13,13 @@ import {
   getMyTeamRank,
   getMyRoles,
   getTeamTotalContributions,
+  getMyRecentActivity,
+  getMyMergeRate,
+  computeStreak,
+  toHeatmapData,
 } from '../../metrics/my-contributions.js';
 import { getDateRange, formatDate, calculatePercentage } from '../../metrics/helpers.js';
+import { getActionQueue } from '../../metrics/my-github-queue.js';
 
 const DASHBOARD_CACHE_TTL = 5 * 60 * 1000;
 const dashboardCache = new Map<string, { data: unknown; ts: number }>();
@@ -407,7 +412,7 @@ export async function metricsRoutes(app: FastifyInstance) {
    *   - days: number of days (default: 30)
    */
   app.get<{
-    Querystring: { days?: string };
+    Querystring: { days?: string; heatmapYear?: string };
   }>('/api/metrics/me', async (request, reply) => {
     try {
       const resolved = await resolveTeamMember(
@@ -430,7 +435,17 @@ export async function metricsRoutes(app: FastifyInstance) {
       const periodStart = dateRange ? formatDate(dateRange.start) : 'All time';
       const periodEnd = dateRange ? formatDate(dateRange.end) : formatDate(new Date());
 
-      const [breakdown, trend, daily, myProjects, rank, roles, teamTotal] = await Promise.all([
+      const heatmapYearParam = request.query.heatmapYear;
+      const heatmapOptions = heatmapYearParam
+        ? {
+            dateRange: {
+              start: new Date(`${heatmapYearParam}-01-01`),
+              end: new Date(`${heatmapYearParam}-12-31`),
+            },
+          }
+        : { days: 365 };
+
+      const [breakdown, trend, daily, myProjects, rank, roles, teamTotal, recentActivity, mergeRateData, heatmapDaily] = await Promise.all([
         getMyContributionBreakdown(resolved.id, options),
         getMyContributionTrend(resolved.id, options),
         getMyDailyActivity(resolved.id, options),
@@ -438,7 +453,13 @@ export async function metricsRoutes(app: FastifyInstance) {
         getMyTeamRank(resolved.id, options),
         getMyRoles(resolved.id),
         getTeamTotalContributions(options),
+        getMyRecentActivity(resolved.id),
+        getMyMergeRate(resolved.id, options),
+        getMyDailyActivity(resolved.id, heatmapOptions),
       ]);
+
+      const streak = computeStreak(heatmapDaily);
+      const heatmap = toHeatmapData(heatmapDaily);
 
       return {
         resolved: true as const,
@@ -470,12 +491,51 @@ export async function metricsRoutes(app: FastifyInstance) {
         dailyActivity: daily,
         projects: myProjects,
         roles,
+        recentActivity,
+        mergeRate: mergeRateData,
+        streak,
+        heatmap,
       };
     } catch (error) {
       logger.error('Error fetching personal metrics', { error });
       reply.status(500);
       return {
         error: 'Failed to fetch personal metrics',
+        message: (error as Error).message,
+      };
+    }
+  });
+
+  /**
+   * GET /api/metrics/me/action-queue
+   *
+   * Live GitHub PR queue for the logged-in user.
+   * Returns open PRs authored by the user and PRs requesting their review,
+   * scoped to tracked project orgs. Cached for 2 minutes per user.
+   */
+  app.get('/api/metrics/me/action-queue', async (request, reply) => {
+    try {
+      const resolved = await resolveTeamMember(
+        request.identity.email || undefined,
+        request.identity.username || undefined,
+      );
+
+      if (!resolved?.githubUsername) {
+        return {
+          resolved: false as const,
+          reason: resolved
+            ? 'No GitHub username linked to your profile'
+            : 'Could not match your login to a team member',
+        };
+      }
+
+      const data = await getActionQueue(resolved.githubUsername);
+      return data;
+    } catch (error) {
+      logger.error('Error fetching action queue', { error });
+      reply.status(500);
+      return {
+        error: 'Failed to fetch action queue',
         message: (error as Error).message,
       };
     }

--- a/backend/src/modules/metrics/my-contributions.ts
+++ b/backend/src/modules/metrics/my-contributions.ts
@@ -1,6 +1,6 @@
 import { db } from '../../shared/database/client.js';
 import { contributions, teamMembers, projects, maintainerStatus, leadershipPositions } from '../../shared/database/schema.js';
-import { eq, and, gte, lte, isNotNull, count, sql } from 'drizzle-orm';
+import { eq, and, gte, lte, isNotNull, count, sql, desc } from 'drizzle-orm';
 import { getDateRange, formatDate, normalizeDateValue, buildCounts, buildTrend, calculatePercentage } from './helpers.js';
 import type { MetricsQueryOptions, TrendMetric, ContributionCounts } from './types.js';
 
@@ -317,4 +317,209 @@ export async function getTeamTotalContributions(
     .where(and(...conditions));
 
   return Number(row?.total ?? 0);
+}
+
+// ---------------------------------------------------------------------------
+// New queries for the Contributor Home page
+// ---------------------------------------------------------------------------
+
+export interface MyRecentActivityItem {
+  type: string;
+  date: string;
+  githubUrl: string;
+  projectName: string;
+  githubOrg: string;
+  githubRepo: string;
+  title: string | null;
+}
+
+/** Recent contributions with GitHub links for the activity feed. */
+export async function getMyRecentActivity(
+  teamMemberId: string,
+  limit = 500,
+): Promise<MyRecentActivityItem[]> {
+  const conditions: ReturnType<typeof eq>[] = [
+    eq(contributions.teamMemberId, teamMemberId),
+    isNotNull(contributions.githubUrl),
+  ];
+
+  const rows = await db
+    .select({
+      type: contributions.contributionType,
+      date: contributions.contributionDate,
+      githubUrl: contributions.githubUrl,
+      metadata: contributions.metadata,
+      collectedAt: contributions.collectedAt,
+      projectName: projects.name,
+      githubOrg: projects.githubOrg,
+      githubRepo: projects.githubRepo,
+    })
+    .from(contributions)
+    .innerJoin(projects, eq(contributions.projectId, projects.id))
+    .where(and(...conditions))
+    .orderBy(desc(contributions.contributionDate), desc(contributions.collectedAt))
+    .limit(limit);
+
+  return rows.map((r) => {
+    const meta = r.metadata as Record<string, unknown> | null;
+    return {
+      type: r.type,
+      date: normalizeDateValue(r.date),
+      githubUrl: r.githubUrl!,
+      projectName: r.projectName,
+      githubOrg: r.githubOrg,
+      githubRepo: r.githubRepo,
+      title: (meta?.title as string) ?? null,
+    };
+  });
+}
+
+export interface MyMergeRate {
+  mergeRate: number;
+  prsMerged: number;
+  prsTotal: number;
+}
+
+/** PR merge rate for a contributor (no line stats, just counts). */
+export async function getMyMergeRate(
+  teamMemberId: string,
+  options: MetricsQueryOptions = {},
+): Promise<MyMergeRate> {
+  const dateRange = getDateRange(options);
+  const conditions: ReturnType<typeof eq>[] = [
+    eq(contributions.teamMemberId, teamMemberId),
+    eq(contributions.contributionType, 'pr'),
+  ];
+  if (dateRange) {
+    conditions.push(gte(contributions.contributionDate, formatDate(dateRange.start)));
+    conditions.push(lte(contributions.contributionDate, formatDate(dateRange.end)));
+  }
+
+  const [row] = await db
+    .select({
+      total: count(),
+      merged: sql<number>`COUNT(*) FILTER (WHERE ${contributions.isMerged} = true)`,
+    })
+    .from(contributions)
+    .where(and(...conditions));
+
+  const prsTotal = Number(row?.total ?? 0);
+  const prsMerged = Number(row?.merged ?? 0);
+
+  return {
+    mergeRate: prsTotal > 0 ? parseFloat(((prsMerged / prsTotal) * 100).toFixed(1)) : 0,
+    prsMerged,
+    prsTotal,
+  };
+}
+
+export interface MyStreak {
+  current: number;
+  longest: number;
+  todayActive: boolean;
+}
+
+function isWeekend(date: Date): boolean {
+  const dow = date.getDay();
+  return dow === 0 || dow === 6;
+}
+
+/**
+ * Compute current and longest contribution streaks from daily activity data.
+ * Weekends (Sat/Sun) are skipped -- a streak only breaks on a weekday with
+ * zero contributions. Weekend contributions still count toward the streak
+ * total if they fall within an active run.
+ */
+export function computeStreak(dailyActivity: MyDailyActivity[]): MyStreak {
+  if (dailyActivity.length === 0) {
+    return { current: 0, longest: 0, todayActive: false };
+  }
+
+  const today = formatDate(new Date());
+
+  const activityMap = new Map<string, number>();
+  for (const day of dailyActivity) {
+    activityMap.set(day.date, day.total);
+  }
+
+  const todayActive = (activityMap.get(today) ?? 0) > 0;
+
+  // Current streak: walk backward from today, skipping weekends without activity.
+  // A streak breaks only when a weekday has 0 contributions.
+  // Max 730 iterations (2 years) as a safety bound.
+  const MAX_LOOKBACK = 730;
+  let current = 0;
+  const cursor = new Date();
+
+  if (!todayActive && !isWeekend(cursor)) {
+    // Today is a weekday with no activity -- check last working day
+    const prev = new Date(cursor);
+    prev.setDate(prev.getDate() - 1);
+    while (isWeekend(prev)) prev.setDate(prev.getDate() - 1);
+    if ((activityMap.get(formatDate(prev)) ?? 0) === 0) {
+      current = 0;
+    } else {
+      const c = new Date(prev);
+      for (let i = 0; i < MAX_LOOKBACK; i++) {
+        const ds = formatDate(c);
+        const total = activityMap.get(ds) ?? 0;
+        if (isWeekend(c)) {
+          if (total > 0) current++;
+          c.setDate(c.getDate() - 1);
+          continue;
+        }
+        if (total > 0) {
+          current++;
+          c.setDate(c.getDate() - 1);
+        } else {
+          break;
+        }
+      }
+    }
+  } else {
+    for (let i = 0; i < MAX_LOOKBACK; i++) {
+      const ds = formatDate(cursor);
+      const total = activityMap.get(ds) ?? 0;
+      if (isWeekend(cursor)) {
+        if (total > 0) current++;
+        cursor.setDate(cursor.getDate() - 1);
+        continue;
+      }
+      if (total > 0) {
+        current++;
+        cursor.setDate(cursor.getDate() - 1);
+      } else {
+        break;
+      }
+    }
+  }
+
+  // Longest streak: scan sorted activity, skipping weekends without activity
+  let longest = 0;
+  let run = 0;
+  const sorted = [...dailyActivity].sort((a, b) => a.date.localeCompare(b.date));
+  for (const day of sorted) {
+    const d = new Date(day.date + 'T00:00:00');
+    if (day.total > 0) {
+      run++;
+      if (run > longest) longest = run;
+    } else if (isWeekend(d)) {
+      // Weekend with no activity doesn't break the streak
+      continue;
+    } else {
+      run = 0;
+    }
+  }
+
+  return { current, longest, todayActive };
+}
+
+export interface HeatmapEntry {
+  date: string;
+  total: number;
+}
+
+/** Extract simplified heatmap data from daily activity. */
+export function toHeatmapData(dailyActivity: MyDailyActivity[]): HeatmapEntry[] {
+  return dailyActivity.map((d) => ({ date: d.date, total: d.total }));
 }

--- a/backend/src/modules/metrics/my-github-queue.ts
+++ b/backend/src/modules/metrics/my-github-queue.ts
@@ -1,0 +1,162 @@
+import { Octokit } from '@octokit/rest';
+import { throttling } from '@octokit/plugin-throttling';
+import { config } from '../../shared/config/index.js';
+import { logger } from '../../shared/utils/logger.js';
+import { db } from '../../shared/database/client.js';
+import { projects } from '../../shared/database/schema.js';
+import { eq } from 'drizzle-orm';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const ThrottledOctokit = Octokit.plugin(throttling as any);
+
+export interface PRItem {
+  title: string;
+  repo: string;
+  number: number;
+  url: string;
+  isDraft: boolean;
+  reviewDecision: string | null;
+  createdAt: string;
+  updatedAt: string;
+  labels: string[];
+}
+
+export interface ActionQueueData {
+  resolved: true;
+  reviewRequests: PRItem[];
+  myOpenPRs: PRItem[];
+}
+
+interface CacheEntry {
+  data: ActionQueueData;
+  timestamp: number;
+}
+
+const CACHE_TTL_MS = 2 * 60 * 1000;
+const cache = new Map<string, CacheEntry>();
+
+let octokitInstance: InstanceType<typeof ThrottledOctokit> | null = null;
+
+function getOctokit(): InstanceType<typeof ThrottledOctokit> {
+  if (!octokitInstance) {
+    octokitInstance = new ThrottledOctokit({
+      auth: config.githubToken,
+      throttle: {
+        onRateLimit: (retryAfter: number, options: Record<string, unknown>, _octokit: unknown, retryCount: number) => {
+          logger.warn(`Action queue rate limit hit for ${options['method']} ${options['url']}, retrying after ${retryAfter}s (attempt ${retryCount + 1})`);
+          return retryCount < 2;
+        },
+        onSecondaryRateLimit: (retryAfter: number, options: Record<string, unknown>) => {
+          logger.warn(`Action queue secondary rate limit for ${options['method']} ${options['url']}, retrying after ${retryAfter}s`);
+          return false;
+        },
+      },
+    });
+  }
+  return octokitInstance;
+}
+
+interface GraphQLPRNode {
+  title: string;
+  number: number;
+  url: string;
+  isDraft: boolean;
+  createdAt: string;
+  updatedAt: string;
+  reviewDecision: string | null;
+  repository: { nameWithOwner: string };
+  labels: { nodes: Array<{ name: string }> };
+}
+
+interface GraphQLSearchResponse {
+  search: {
+    nodes: GraphQLPRNode[];
+  };
+}
+
+const PR_SEARCH_QUERY = `
+  query($query: String!) {
+    search(query: $query, type: ISSUE, first: 20) {
+      nodes {
+        ... on PullRequest {
+          title
+          number
+          url
+          isDraft
+          createdAt
+          updatedAt
+          reviewDecision
+          repository { nameWithOwner }
+          labels(first: 5) { nodes { name } }
+        }
+      }
+    }
+  }
+`;
+
+function buildOrgFilter(orgs: string[]): string {
+  if (orgs.length === 0) return '';
+  return orgs.map((o) => `org:${o}`).join(' ');
+}
+
+function mapPRNodes(nodes: GraphQLPRNode[]): PRItem[] {
+  return nodes
+    .filter((n) => n.title)
+    .map((n) => ({
+      title: n.title,
+      repo: n.repository.nameWithOwner,
+      number: n.number,
+      url: n.url,
+      isDraft: n.isDraft,
+      reviewDecision: n.reviewDecision ?? null,
+      createdAt: n.createdAt,
+      updatedAt: n.updatedAt,
+      labels: n.labels.nodes.map((l) => l.name),
+    }));
+}
+
+async function fetchFromGitHub(
+  githubUsername: string,
+  trackedOrgs: string[],
+): Promise<ActionQueueData> {
+  const octokit = getOctokit();
+  const orgFilter = buildOrgFilter(trackedOrgs);
+
+  const reviewQuery = `is:pr is:open review-requested:${githubUsername} ${orgFilter}`.trim();
+  const authorQuery = `is:pr is:open author:${githubUsername} ${orgFilter}`.trim();
+
+  const [reviewResult, authorResult]: [GraphQLSearchResponse, GraphQLSearchResponse] = await Promise.all([
+    octokit.graphql(PR_SEARCH_QUERY, { query: reviewQuery }),
+    octokit.graphql(PR_SEARCH_QUERY, { query: authorQuery }),
+  ]);
+
+  return {
+    resolved: true,
+    reviewRequests: mapPRNodes(reviewResult.search.nodes),
+    myOpenPRs: mapPRNodes(authorResult.search.nodes),
+  };
+}
+
+export async function getTrackedOrgs(): Promise<string[]> {
+  const rows = await db
+    .selectDistinct({ githubOrg: projects.githubOrg })
+    .from(projects)
+    .where(eq(projects.trackingEnabled, true));
+
+  return rows.map((r) => r.githubOrg);
+}
+
+export async function getActionQueue(
+  githubUsername: string,
+): Promise<ActionQueueData> {
+  const cached = cache.get(githubUsername);
+  if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+    return cached.data;
+  }
+
+  const trackedOrgs = await getTrackedOrgs();
+  const data = await fetchFromGitHub(githubUsername, trackedOrgs);
+
+  cache.set(githubUsername, { data, timestamp: Date.now() });
+  return data;
+}

--- a/frontend/src/components/profile/ActionQueue.tsx
+++ b/frontend/src/components/profile/ActionQueue.tsx
@@ -1,0 +1,152 @@
+import { useState } from 'react';
+import { ExternalLink, CheckCircle2 } from 'lucide-react';
+
+interface PRItem {
+  title: string;
+  repo: string;
+  number: number;
+  url: string;
+  isDraft: boolean;
+  reviewDecision: string | null;
+  createdAt: string;
+  updatedAt: string;
+  labels: string[];
+}
+
+interface ActionQueueProps {
+  reviewRequests: PRItem[];
+  myOpenPRs: PRItem[];
+}
+
+const VISIBLE_LIMIT = 5;
+
+function relativeAge(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  if (hours < 1) return '<1h';
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d`;
+  const weeks = Math.floor(days / 7);
+  return `${weeks}w`;
+}
+
+function statusPill(pr: PRItem): { label: string; className: string } {
+  if (pr.isDraft) return { label: 'Draft', className: 'bg-gray-100 text-gray-600' };
+  switch (pr.reviewDecision) {
+    case 'APPROVED':
+      return { label: 'Approved', className: 'bg-green-100 text-green-700' };
+    case 'CHANGES_REQUESTED':
+      return { label: 'Changes', className: 'bg-amber-100 text-amber-700' };
+    case 'REVIEW_REQUIRED':
+      return { label: 'Needs review', className: 'bg-blue-100 text-blue-700' };
+    default:
+      return { label: 'Open', className: 'bg-blue-50 text-blue-600' };
+  }
+}
+
+function PRRow({ pr }: { pr: PRItem }) {
+  const status = statusPill(pr);
+  return (
+    <a
+      href={pr.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-3 py-2.5 px-3 -mx-3 rounded-lg hover:bg-gray-50 transition-colors group"
+    >
+      <span className={`shrink-0 text-[10px] font-semibold px-1.5 py-0.5 rounded-full ${status.className}`}>
+        {status.label}
+      </span>
+      <span className="text-xs text-gray-400 shrink-0 font-mono">
+        {pr.repo.split('/')[1]}#{pr.number}
+      </span>
+      <span className="text-sm text-gray-700 truncate flex-1">{pr.title}</span>
+      <span className="text-xs text-gray-400 shrink-0 tabular-nums">{relativeAge(pr.createdAt)}</span>
+      <ExternalLink className="w-3 h-3 text-gray-300 group-hover:text-gray-500 shrink-0" />
+    </a>
+  );
+}
+
+function PRGroup({
+  title,
+  count,
+  items,
+}: {
+  title: string;
+  count: number;
+  items: PRItem[];
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const visible = expanded ? items : items.slice(0, VISIBLE_LIMIT);
+  const hasMore = items.length > VISIBLE_LIMIT;
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-4">
+      <div className="flex items-center justify-between mb-1">
+        <h3 className="text-sm font-semibold text-gray-900">{title}</h3>
+        {count > 0 && (
+          <span className="text-xs font-semibold text-gray-500 bg-gray-100 px-2 py-0.5 rounded-full">
+            {count}
+          </span>
+        )}
+      </div>
+      {items.length === 0 ? (
+        <div className="flex items-center gap-2 py-3 text-sm text-gray-400">
+          <CheckCircle2 className="w-4 h-4 text-green-400" />
+          All clear
+        </div>
+      ) : (
+        <>
+          <div className="divide-y divide-gray-50">
+            {visible.map((pr) => (
+              <PRRow key={`${pr.repo}-${pr.number}`} pr={pr} />
+            ))}
+          </div>
+          {hasMore && (
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="w-full text-center pt-2 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors"
+            >
+              {expanded ? 'Show less' : `Show ${items.length - VISIBLE_LIMIT} more`}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export function ActionQueue({ reviewRequests, myOpenPRs }: ActionQueueProps) {
+  const allClear = reviewRequests.length === 0 && myOpenPRs.length === 0;
+
+  if (allClear) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-4 text-sm text-gray-400 bg-white rounded-xl shadow-sm border border-gray-100">
+        <CheckCircle2 className="w-4 h-4 text-green-400" />
+        All clear — nothing needs your attention
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <PRGroup title="Needs Your Review" count={reviewRequests.length} items={reviewRequests} />
+      <PRGroup title="My Open PRs" count={myOpenPRs.length} items={myOpenPRs} />
+    </div>
+  );
+}
+
+export function ActionQueueSkeleton() {
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      {[0, 1].map((i) => (
+        <div key={i} className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 space-y-3">
+          <div className="h-4 w-32 bg-gray-100 rounded animate-pulse" />
+          <div className="h-8 w-full bg-gray-50 rounded animate-pulse" />
+          <div className="h-8 w-full bg-gray-50 rounded animate-pulse" />
+          <div className="h-8 w-3/4 bg-gray-50 rounded animate-pulse" />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/ContributionHeatmap.tsx
+++ b/frontend/src/components/profile/ContributionHeatmap.tsx
@@ -1,0 +1,304 @@
+import { useMemo, useState, useCallback, useRef, useEffect } from 'react';
+import { ChevronDown, Check } from 'lucide-react';
+
+interface HeatmapEntry {
+  date: string;
+  total: number;
+}
+
+interface StreakInfo {
+  current: number;
+  longest: number;
+}
+
+interface ContributionHeatmapProps {
+  data: HeatmapEntry[];
+  streak: StreakInfo;
+  onYearChange?: (year: number | null) => void;
+  onDateSelect?: (date: string | null) => void;
+  selectedDate?: string | null;
+  memberSince?: string | null;
+}
+
+function getIntensity(count: number): string {
+  if (count === 0) return 'bg-gray-100';
+  if (count <= 3) return 'bg-blue-200';
+  if (count <= 7) return 'bg-blue-400';
+  return 'bg-blue-600';
+}
+
+const DAY_LABELS = ['', 'Mon', '', 'Wed', '', 'Fri', ''];
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+const CELL_SIZE = 14;
+const CELL_GAP = 3;
+
+interface DayCell {
+  date: string;
+  total: number;
+  dayOfWeek: number;
+}
+
+interface WeekColumn {
+  days: Array<DayCell | null>;
+  monthLabel: string | null;
+}
+
+interface TooltipData {
+  date: string;
+  total: number;
+  x: number;
+  y: number;
+}
+
+function buildWeeks(data: HeatmapEntry[]): WeekColumn[] {
+  if (data.length === 0) return [];
+
+  const dateMap = new Map(data.map((d) => [d.date, d.total]));
+
+  const allDates = data.map((d) => d.date).sort();
+  const endDate = new Date(allDates[allDates.length - 1] + 'T00:00:00');
+  const startDate = new Date(allDates[0] + 'T00:00:00');
+
+  const startDow = startDate.getDay();
+  if (startDow !== 0) startDate.setDate(startDate.getDate() - startDow);
+
+  const weeks: WeekColumn[] = [];
+  const cursor = new Date(startDate);
+  let prevMonth = -1;
+  const firstDataDate = new Date(allDates[0] + 'T00:00:00');
+
+  while (cursor <= endDate) {
+    const week: WeekColumn = { days: [], monthLabel: null };
+    for (let dow = 0; dow < 7; dow++) {
+      const ds = cursor.toISOString().split('T')[0];
+      const month = cursor.getMonth();
+
+      if (dow === 0 && month !== prevMonth) {
+        week.monthLabel = MONTH_NAMES[month];
+        prevMonth = month;
+      }
+
+      if (cursor > endDate || cursor < firstDataDate) {
+        week.days.push(null);
+      } else {
+        week.days.push({ date: ds, total: dateMap.get(ds) ?? 0, dayOfWeek: dow });
+      }
+      cursor.setDate(cursor.getDate() + 1);
+    }
+    weeks.push(week);
+  }
+
+  return weeks;
+}
+
+function formatTooltipDate(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function getAvailableYears(memberSince?: string | null): number[] {
+  const currentYear = new Date().getFullYear();
+  const memberYear = memberSince ? new Date(memberSince).getFullYear() : currentYear;
+  const startYear = Math.min(memberYear, currentYear - 3);
+  const years: number[] = [];
+  for (let y = currentYear; y >= startYear; y--) years.push(y);
+  return years;
+}
+
+export function ContributionHeatmap({ data, streak, onYearChange, onDateSelect, selectedDate, memberSince }: ContributionHeatmapProps) {
+  const [selectedYear, setSelectedYear] = useState<number | null>(null);
+  const [tooltip, setTooltip] = useState<TooltipData | null>(null);
+  const [yearOpen, setYearOpen] = useState(false);
+  const gridRef = useRef<HTMLDivElement>(null);
+  const yearDropdownRef = useRef<HTMLDivElement>(null);
+
+  const weeks = useMemo(() => buildWeeks(data), [data]);
+  const yearTotal = useMemo(() => data.reduce((sum, d) => sum + d.total, 0), [data]);
+  const availableYears = useMemo(() => getAvailableYears(memberSince), [memberSince]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (yearDropdownRef.current && !yearDropdownRef.current.contains(e.target as Node)) setYearOpen(false);
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleYearSelect = useCallback((year: number | null) => {
+    setSelectedYear(year);
+    setYearOpen(false);
+    onYearChange?.(year);
+  }, [onYearChange]);
+
+  const handleCellHover = useCallback((e: React.MouseEvent, day: DayCell) => {
+    const gridRect = gridRef.current?.getBoundingClientRect();
+    if (!gridRect) return;
+    const cellRect = (e.target as HTMLElement).getBoundingClientRect();
+    setTooltip({
+      date: day.date,
+      total: day.total,
+      x: cellRect.left - gridRect.left + cellRect.width / 2,
+      y: cellRect.top - gridRect.top - 8,
+    });
+  }, []);
+
+  const handleCellLeave = useCallback(() => setTooltip(null), []);
+
+  const handleCellClick = useCallback((day: DayCell) => {
+    if (!onDateSelect) return;
+    onDateSelect(selectedDate === day.date ? null : day.date);
+  }, [onDateSelect, selectedDate]);
+
+  const yearLabel = selectedYear ? String(selectedYear) : 'Last 12 months';
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-5">
+        <h2 className="text-sm font-semibold text-gray-900">Contribution Heatmap</h2>
+        <div className="relative" ref={yearDropdownRef}>
+          <button
+            onClick={() => setYearOpen(!yearOpen)}
+            className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors border ${
+              yearOpen
+                ? 'bg-white border-blue-300 ring-2 ring-blue-100 text-gray-700'
+                : 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
+            }`}
+          >
+            {yearLabel}
+            <ChevronDown className={`w-3 h-3 transition-transform ${yearOpen ? 'rotate-180' : ''}`} />
+          </button>
+          {yearOpen && (
+            <div className="absolute top-full right-0 mt-1.5 z-30 w-44 bg-white rounded-xl shadow-lg border border-gray-200 py-1 max-h-56 overflow-y-auto">
+              <button
+                onClick={() => handleYearSelect(null)}
+                className={`w-full flex items-center gap-2 px-3 py-2 text-xs text-left transition-colors ${
+                  selectedYear === null ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-50'
+                }`}
+              >
+                {selectedYear === null ? <Check className="w-3 h-3 text-blue-600 shrink-0" /> : <div className="w-3 shrink-0" />}
+                Last 12 months
+              </button>
+              <div className="border-t border-gray-100 my-1" />
+              {availableYears.map((y) => (
+                <button
+                  key={y}
+                  onClick={() => handleYearSelect(y)}
+                  className={`w-full flex items-center gap-2 px-3 py-2 text-xs text-left transition-colors ${
+                    selectedYear === y ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  {selectedYear === y ? <Check className="w-3 h-3 text-blue-600 shrink-0" /> : <div className="w-3 shrink-0" />}
+                  {y}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Grid container */}
+      <div className="relative" ref={gridRef}>
+        <div className="overflow-x-auto overflow-y-visible">
+          <div className="min-w-fit mx-auto w-fit pb-1">
+            {/* Tooltip */}
+            {tooltip && (
+              <div
+                className="absolute z-20 pointer-events-none whitespace-nowrap -translate-x-1/2 -translate-y-full"
+                style={{ left: tooltip.x, top: tooltip.y }}
+              >
+                <div className="bg-gray-900 text-white text-[11px] px-2.5 py-1.5 rounded-lg shadow-lg mb-1">
+                  <span className="font-semibold">{tooltip.total}</span>
+                  {' '}contribution{tooltip.total !== 1 ? 's' : ''} on {formatTooltipDate(tooltip.date)}
+                </div>
+                <div className="w-2 h-2 bg-gray-900 rotate-45 mx-auto -mt-2" />
+              </div>
+            )}
+
+            {/* Month labels row */}
+            <div className="flex" style={{ paddingLeft: 32 }}>
+              {weeks.map((w, i) => (
+                <div
+                  key={i}
+                  className="text-[10px] text-gray-400 leading-none"
+                  style={{ width: CELL_SIZE, marginRight: CELL_GAP }}
+                >
+                  {w.monthLabel ?? ''}
+                </div>
+              ))}
+            </div>
+
+            <div className="flex mt-1">
+              {/* Day-of-week labels */}
+              <div className="flex flex-col shrink-0" style={{ width: 28, marginRight: 4 }}>
+                {DAY_LABELS.map((label, i) => (
+                  <div
+                    key={i}
+                    className="text-[10px] text-gray-400 text-right pr-1"
+                    style={{ height: CELL_SIZE, marginBottom: CELL_GAP, lineHeight: `${CELL_SIZE}px` }}
+                  >
+                    {label}
+                  </div>
+                ))}
+              </div>
+
+              {/* Week columns */}
+              {weeks.map((week, wi) => (
+                <div key={wi} className="flex flex-col" style={{ marginRight: CELL_GAP }}>
+                  {week.days.map((day, di) => {
+                    const isSelected = day != null && selectedDate === day.date;
+                    return (
+                      <div
+                        key={di}
+                        className={`rounded-[3px] transition-all duration-75 ${
+                          day
+                            ? `${getIntensity(day.total)} cursor-pointer ${
+                                isSelected
+                                  ? 'ring-2 ring-blue-600 ring-offset-1 scale-125 z-10'
+                                  : 'hover:ring-2 hover:ring-blue-500 hover:ring-offset-1 hover:scale-125'
+                              }`
+                            : ''
+                        }`}
+                        style={{
+                          width: CELL_SIZE,
+                          height: CELL_SIZE,
+                          marginBottom: CELL_GAP,
+                        }}
+                        onClick={day ? () => handleCellClick(day) : undefined}
+                        onMouseEnter={day ? (e) => handleCellHover(e, day) : undefined}
+                        onMouseLeave={day ? handleCellLeave : undefined}
+                        aria-label={day ? `${day.total} contributions on ${day.date}` : undefined}
+                      />
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+      {/* Footer: streak stats + legend */}
+      <div className="flex flex-wrap items-center justify-between mt-4 pt-3 border-t border-gray-100 gap-y-2">
+        <div className="flex items-center gap-4 text-xs text-gray-500">
+          {streak.current > 0 && (
+            <span>Current streak: <span className="font-semibold text-gray-700">{streak.current} days</span></span>
+          )}
+          {streak.longest > 0 && (
+            <span>Longest: <span className="font-semibold text-gray-700">{streak.longest} days</span></span>
+          )}
+          <span><span className="font-semibold text-gray-700">{yearTotal.toLocaleString()}</span> this year</span>
+        </div>
+
+        <div className="flex items-center gap-1 text-[10px] text-gray-400">
+          <span>Less</span>
+          <div className="w-[10px] h-[10px] rounded-[2px] bg-gray-100" />
+          <div className="w-[10px] h-[10px] rounded-[2px] bg-blue-200" />
+          <div className="w-[10px] h-[10px] rounded-[2px] bg-blue-400" />
+          <div className="w-[10px] h-[10px] rounded-[2px] bg-blue-600" />
+          <span>More</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/profile/RecentActivityFeed.tsx
+++ b/frontend/src/components/profile/RecentActivityFeed.tsx
@@ -1,0 +1,279 @@
+import { useState, useMemo, useRef, useEffect } from 'react';
+import { GitCommit, GitPullRequest, MessageSquare, AlertCircle, ExternalLink, ChevronDown, Check, FolderGit2 } from 'lucide-react';
+
+interface RecentActivityItem {
+  type: string;
+  date: string;
+  githubUrl: string;
+  projectName: string;
+  githubOrg: string;
+  githubRepo: string;
+  title: string | null;
+}
+
+interface RecentActivityFeedProps {
+  items: RecentActivityItem[];
+  dateFilter?: string | null;
+  onClearDateFilter?: () => void;
+}
+
+const PAGE_SIZE = 15;
+
+const TYPE_CONFIG: Record<string, { icon: React.ElementType; color: string; bgColor: string; label: string }> = {
+  commit: { icon: GitCommit, color: 'text-blue-600', bgColor: 'bg-blue-50', label: 'Commit' },
+  pr: { icon: GitPullRequest, color: 'text-purple-600', bgColor: 'bg-purple-50', label: 'PR' },
+  review: { icon: MessageSquare, color: 'text-green-600', bgColor: 'bg-green-50', label: 'Review' },
+  issue: { icon: AlertCircle, color: 'text-amber-600', bgColor: 'bg-amber-50', label: 'Issue' },
+};
+
+const ALL_TYPES = ['commit', 'pr', 'review', 'issue'] as const;
+
+function relativeTime(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr + 'T12:00:00').getTime();
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  if (hours < 1) return 'Today';
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days === 1) return 'Yesterday';
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  if (weeks < 5) return `${weeks}w ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+function ProjectDropdown({
+  projects,
+  selected,
+  onSelect,
+}: {
+  projects: string[];
+  selected: string;
+  onSelect: (value: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const label = selected === 'all' ? 'All projects' : selected.split('/').pop() ?? selected;
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(!open)}
+        className={`inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors border ${
+          open
+            ? 'bg-white border-blue-300 ring-2 ring-blue-100 text-gray-700'
+            : selected === 'all'
+              ? 'bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100'
+              : 'bg-blue-50 border-blue-200 text-blue-700 hover:bg-blue-100'
+        }`}
+      >
+        <FolderGit2 className="w-3 h-3" />
+        <span className="max-w-[140px] truncate">{label}</span>
+        <ChevronDown className={`w-3 h-3 transition-transform ${open ? 'rotate-180' : ''}`} />
+      </button>
+
+      {open && (
+        <div className="absolute top-full left-0 mt-1.5 z-30 w-64 bg-white rounded-xl shadow-lg border border-gray-200 py-1 max-h-64 overflow-y-auto">
+          <button
+            onClick={() => { onSelect('all'); setOpen(false); }}
+            className={`w-full flex items-center gap-2 px-3 py-2 text-xs text-left transition-colors ${
+              selected === 'all' ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-50'
+            }`}
+          >
+            {selected === 'all' && <Check className="w-3 h-3 text-blue-600 shrink-0" />}
+            {selected !== 'all' && <div className="w-3 shrink-0" />}
+            All projects
+          </button>
+          <div className="border-t border-gray-100 my-1" />
+          {projects.map((p) => (
+            <button
+              key={p}
+              onClick={() => { onSelect(p); setOpen(false); }}
+              className={`w-full flex items-center gap-2 px-3 py-2 text-xs text-left transition-colors ${
+                selected === p ? 'bg-blue-50 text-blue-700 font-medium' : 'text-gray-700 hover:bg-gray-50'
+              }`}
+            >
+              {selected === p && <Check className="w-3 h-3 text-blue-600 shrink-0" />}
+              {selected !== p && <div className="w-3 shrink-0" />}
+              <span className="truncate">{p}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function RecentActivityFeed({ items, dateFilter, onClearDateFilter }: RecentActivityFeedProps) {
+  const [activeTypes, setActiveTypes] = useState<Set<string>>(new Set(ALL_TYPES));
+  const [selectedProject, setSelectedProject] = useState<string>('all');
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+
+  const projects = useMemo(() => {
+    const set = new Set<string>();
+    for (const item of items) set.add(`${item.githubOrg}/${item.githubRepo}`);
+    return Array.from(set).sort();
+  }, [items]);
+
+  const filtered = useMemo(() => {
+    return items.filter((item) => {
+      if (dateFilter && item.date !== dateFilter) return false;
+      if (!activeTypes.has(item.type)) return false;
+      if (selectedProject !== 'all' && `${item.githubOrg}/${item.githubRepo}` !== selectedProject) return false;
+      return true;
+    });
+  }, [items, activeTypes, selectedProject, dateFilter]);
+
+  const visible = filtered.slice(0, visibleCount);
+  const hasMore = filtered.length > visibleCount;
+
+  const toggleType = (type: string) => {
+    setActiveTypes((prev) => {
+      const next = new Set(prev);
+      if (next.has(type)) {
+        if (next.size > 1) next.delete(type);
+      } else {
+        next.add(type);
+      }
+      return next;
+    });
+    setVisibleCount(PAGE_SIZE);
+  };
+
+  if (items.length === 0) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+        <h2 className="text-sm font-semibold text-gray-900 mb-4">Recent Activity</h2>
+        <p className="text-sm text-gray-400 py-6 text-center">No recent activity with links</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+      <h2 className="text-sm font-semibold text-gray-900 mb-4">Recent Activity</h2>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-3 mb-4">
+        {/* Type chips */}
+        <div className="flex gap-1.5">
+          {ALL_TYPES.map((type) => {
+            const cfg = TYPE_CONFIG[type];
+            const active = activeTypes.has(type);
+            return (
+              <button
+                key={type}
+                onClick={() => toggleType(type)}
+                className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium transition-colors ${
+                  active
+                    ? `${cfg.bgColor} ${cfg.color} ring-1 ring-inset ring-current/20`
+                    : 'bg-gray-50 text-gray-400 hover:bg-gray-100'
+                }`}
+              >
+                <cfg.icon className="w-3 h-3" />
+                {cfg.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Project dropdown */}
+        {projects.length > 1 && (
+          <ProjectDropdown
+            projects={projects}
+            selected={selectedProject}
+            onSelect={(v) => { setSelectedProject(v); setVisibleCount(PAGE_SIZE); }}
+          />
+        )}
+
+        {/* Date filter chip */}
+        {dateFilter && (
+          <button
+            onClick={onClearDateFilter}
+            className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-200 hover:bg-blue-100 transition-colors"
+          >
+            {new Date(dateFilter + 'T00:00:00').toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' })}
+            <span className="text-blue-400 hover:text-blue-600">&times;</span>
+          </button>
+        )}
+
+        <span className="text-[11px] text-gray-400 ml-auto">
+          {filtered.length} {filtered.length === 1 ? 'item' : 'items'}
+        </span>
+      </div>
+
+      {/* Table */}
+      {filtered.length === 0 ? (
+        <p className="text-sm text-gray-400 py-6 text-center">No matches for selected filters</p>
+      ) : (
+        <div className="overflow-x-auto -mx-2">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-100">
+                <th className="text-left py-2 px-2 text-[10px] font-semibold text-gray-400 uppercase tracking-wider w-20">Type</th>
+                <th className="text-left py-2 px-2 text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Project</th>
+                <th className="text-left py-2 px-2 text-[10px] font-semibold text-gray-400 uppercase tracking-wider">Title</th>
+                <th className="text-right py-2 px-2 text-[10px] font-semibold text-gray-400 uppercase tracking-wider w-20">Date</th>
+                <th className="w-8" />
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((item, i) => {
+                const cfg = TYPE_CONFIG[item.type] ?? TYPE_CONFIG.commit;
+                const Icon = cfg.icon;
+                return (
+                  <tr
+                    key={`${item.type}-${item.githubUrl}-${i}`}
+                    className="border-b border-gray-50 hover:bg-gray-50/50 transition-colors group"
+                  >
+                    <td className="py-2 px-2">
+                      <span className={`inline-flex items-center gap-1 text-xs font-medium ${cfg.color}`}>
+                        <Icon className="w-3.5 h-3.5" />
+                        {cfg.label}
+                      </span>
+                    </td>
+                    <td className="py-2 px-2 text-xs text-gray-500 font-mono">{item.githubOrg}/{item.githubRepo}</td>
+                    <td className="py-2 px-2 text-sm text-gray-700 truncate max-w-[300px]">
+                      {item.title || <span className="text-gray-300 italic">No title</span>}
+                    </td>
+                    <td className="py-2 px-2 text-right text-xs text-gray-400 tabular-nums whitespace-nowrap">
+                      {relativeTime(item.date)}
+                    </td>
+                    <td className="py-2 px-1">
+                      <a
+                        href={item.githubUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-gray-300 hover:text-blue-500 transition-colors"
+                      >
+                        <ExternalLink className="w-3.5 h-3.5" />
+                      </a>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {hasMore && (
+        <button
+          onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+          className="w-full text-center pt-3 text-xs font-medium text-blue-600 hover:text-blue-800 transition-colors"
+        >
+          Show {Math.min(PAGE_SIZE, filtered.length - visibleCount)} more
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/profile/StreakBadge.tsx
+++ b/frontend/src/components/profile/StreakBadge.tsx
@@ -1,0 +1,111 @@
+import { useState, useRef } from 'react';
+import { Flame, Zap, Trophy } from 'lucide-react';
+
+interface StreakBadgeProps {
+  current: number;
+  longest: number;
+  todayActive: boolean;
+}
+
+function getStreakTier(days: number): { label: string; gradient: string; ring: string; icon: React.ElementType; glow: string } {
+  if (days >= 30) return { label: 'On fire', gradient: 'from-orange-500 to-red-500', ring: 'ring-orange-300', icon: Flame, glow: 'shadow-orange-200' };
+  if (days >= 14) return { label: 'Blazing', gradient: 'from-amber-500 to-orange-500', ring: 'ring-amber-300', icon: Flame, glow: 'shadow-amber-200' };
+  if (days >= 7) return { label: 'Rolling', gradient: 'from-yellow-400 to-amber-500', ring: 'ring-yellow-300', icon: Zap, glow: 'shadow-yellow-200' };
+  return { label: 'Building', gradient: 'from-blue-400 to-indigo-500', ring: 'ring-blue-300', icon: Zap, glow: 'shadow-blue-200' };
+}
+
+export function StreakBadge({ current, longest, todayActive }: StreakBadgeProps) {
+  const [showTooltip, setShowTooltip] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const hasActiveStreak = current > 0;
+  const tier = hasActiveStreak ? getStreakTier(current) : null;
+  const Icon = tier?.icon ?? Flame;
+  const isPersonalBest = hasActiveStreak && current >= longest && longest > 0;
+
+  return (
+    <div
+      className="relative"
+      ref={ref}
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
+      {/* Badge */}
+      {hasActiveStreak ? (
+        <div className={`inline-flex items-center gap-1.5 px-3 py-1 rounded-full cursor-default bg-gradient-to-r ${tier!.gradient} text-white text-xs font-bold shadow-md ${tier!.glow} ring-2 ${tier!.ring} ring-offset-1`}>
+          <Icon className="w-3.5 h-3.5 animate-pulse" />
+          <span>{current}-day streak</span>
+        </div>
+      ) : (
+        <div className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full cursor-default bg-gray-100 text-gray-500 text-xs font-semibold">
+          <Flame className="w-3.5 h-3.5 text-gray-400" />
+          <span>{longest > 0 ? `Best: ${longest}d` : 'No streak'}</span>
+        </div>
+      )}
+
+      {/* Tooltip */}
+      {showTooltip && (
+        <div className="absolute top-full left-1/2 -translate-x-1/2 mt-2.5 z-30">
+          <div className="w-2.5 h-2.5 bg-gray-900 rotate-45 mx-auto -mb-1.5" />
+          <div className="bg-gray-900 text-white rounded-xl shadow-xl px-4 py-3.5 w-56">
+            <div className="flex items-center gap-2 mb-3">
+              <div className={`w-8 h-8 rounded-lg flex items-center justify-center ${
+                hasActiveStreak
+                  ? `bg-gradient-to-br ${tier!.gradient}`
+                  : 'bg-gray-700'
+              }`}>
+                <Icon className="w-4 h-4 text-white" />
+              </div>
+              <div>
+                <p className="text-sm font-bold">
+                  {hasActiveStreak ? tier!.label : 'No active streak'}
+                </p>
+                <p className="text-[11px] text-gray-400">
+                  {hasActiveStreak ? `${current} consecutive days` : 'Start contributing to build one'}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-2 text-[11px]">
+              <div className="flex justify-between">
+                <span className="text-gray-400">Today</span>
+                <span className={todayActive ? 'text-green-400 font-medium' : 'text-gray-500'}>
+                  {todayActive ? 'Active' : 'Not yet'}
+                </span>
+              </div>
+
+              {hasActiveStreak && (
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Current streak</span>
+                  <span className="text-white font-medium">{current} days</span>
+                </div>
+              )}
+
+              {longest > 0 && (
+                <div className="flex justify-between">
+                  <span className="text-gray-400">Longest streak</span>
+                  <span className="text-white font-medium flex items-center gap-1">
+                    {isPersonalBest && <Trophy className="w-3 h-3 text-amber-400" />}
+                    {longest} days
+                  </span>
+                </div>
+              )}
+
+              {isPersonalBest && (
+                <div className="pt-1.5 mt-1.5 border-t border-gray-700 text-center">
+                  <span className="text-amber-400 font-semibold text-[10px] uppercase tracking-wider">Personal best!</span>
+                </div>
+              )}
+
+              {!todayActive && hasActiveStreak && (
+                <div className="pt-1.5 mt-1.5 border-t border-gray-700 text-center">
+                  <span className="text-gray-500 text-[10px]">Contribute today to keep it going</span>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/MyContributions.tsx
+++ b/frontend/src/pages/MyContributions.tsx
@@ -3,13 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 import { useSearchParams, Link } from 'react-router-dom';
 import {
   GitCommit,
-  GitPullRequest,
-  MessageSquare,
-  AlertCircle,
   FolderGit2,
-  BarChart3,
-  Star,
-  Calendar,
+  GitMerge,
   UserX,
   Crown,
   ExternalLink,
@@ -24,7 +19,6 @@ import {
 } from 'recharts';
 import {
   DEFAULT_PERIOD_DAYS,
-  StatCard,
   PeriodSelector,
 } from '../components/dashboard';
 import type { TrendMetric } from '../components/dashboard/types';
@@ -32,6 +26,14 @@ import { PageError } from '../components/common/PageError';
 import { StatCardSkeleton, Skeleton } from '../components/common/Skeleton';
 import { useAuth } from '../context/AuthContext';
 import { apiFetch } from '../lib/api';
+import { StreakBadge } from '../components/profile/StreakBadge';
+import { ContributionHeatmap } from '../components/profile/ContributionHeatmap';
+import { ActionQueue, ActionQueueSkeleton } from '../components/profile/ActionQueue';
+import { RecentActivityFeed } from '../components/profile/RecentActivityFeed';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 
 interface DailyActivity {
   date: string;
@@ -70,6 +72,45 @@ interface LeadershipRole {
   votingRights: boolean;
 }
 
+interface RecentActivityItem {
+  type: string;
+  date: string;
+  githubUrl: string;
+  projectName: string;
+  githubOrg: string;
+  githubRepo: string;
+  title: string | null;
+}
+
+interface StreakData {
+  current: number;
+  longest: number;
+  todayActive: boolean;
+}
+
+interface HeatmapEntry {
+  date: string;
+  total: number;
+}
+
+interface PRItem {
+  title: string;
+  repo: string;
+  number: number;
+  url: string;
+  isDraft: boolean;
+  reviewDecision: string | null;
+  createdAt: string;
+  updatedAt: string;
+  labels: string[];
+}
+
+interface ActionQueueData {
+  resolved: true;
+  reviewRequests: PRItem[];
+  myOpenPRs: PRItem[];
+}
+
 interface MyContributionsResolved {
   resolved: true;
   profile: {
@@ -103,6 +144,10 @@ interface MyContributionsResolved {
     maintainer: MaintainerRole[];
     leadership: LeadershipRole[];
   };
+  recentActivity: RecentActivityItem[];
+  mergeRate: { mergeRate: number; prsMerged: number; prsTotal: number };
+  streak: StreakData;
+  heatmap: HeatmapEntry[];
 }
 
 interface MyContributionsUnresolved {
@@ -113,11 +158,29 @@ interface MyContributionsUnresolved {
 
 type MyContributionsData = MyContributionsResolved | MyContributionsUnresolved;
 
-async function fetchMyContributions(days: number): Promise<MyContributionsData> {
-  const res = await apiFetch(`/api/metrics/me?days=${days}`);
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
+
+async function fetchMyContributions(days: number, heatmapYear?: number | null): Promise<MyContributionsData> {
+  const params = new URLSearchParams({ days: String(days) });
+  if (heatmapYear) params.set('heatmapYear', String(heatmapYear));
+  const res = await apiFetch(`/api/metrics/me?${params}`);
   if (!res.ok) throw new Error('Failed to fetch personal metrics');
   return res.json();
 }
+
+async function fetchActionQueue(): Promise<ActionQueueData | null> {
+  const res = await apiFetch('/api/metrics/me/action-queue');
+  if (!res.ok) return null;
+  const data = await res.json();
+  if (!data.resolved) return null;
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components (kept from original page)
+// ---------------------------------------------------------------------------
 
 function UnlinkedState({ username, email }: { username: string; email: string }) {
   return (
@@ -130,7 +193,7 @@ function UnlinkedState({ username, email }: { username: string; email: string })
           Account not linked
         </h2>
         <p className="text-sm text-gray-500 mb-4 leading-relaxed">
-          We couldn't match your login to a team member profile. Your personal
+          We couldn&apos;t match your login to a team member profile. Your personal
           contribution dashboard will appear once your account is linked.
         </p>
         <div className="bg-white rounded-xl border border-gray-200 p-4 text-left text-sm">
@@ -252,30 +315,6 @@ function ActivityChart({ data }: { data: DailyActivity[] }) {
   );
 }
 
-interface BreakdownCardProps {
-  title: string;
-  count: number;
-  icon: React.ElementType;
-  color: string;
-  bgColor: string;
-}
-
-function BreakdownCard({ title, count, icon: Icon, color, bgColor }: BreakdownCardProps) {
-  return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-      <div className="flex items-center gap-2 mb-3">
-        <div className={`p-2 rounded-lg ${bgColor}`}>
-          <Icon className={`w-4 h-4 ${color}`} />
-        </div>
-        <span className="text-sm font-medium text-gray-600">{title}</span>
-      </div>
-      <p className="text-2xl font-bold text-gray-900">
-        {count.toLocaleString()}
-      </p>
-    </div>
-  );
-}
-
 const PROJECTS_LIMIT = 5;
 
 function ProjectsTable({ projects }: { projects: ProjectContributions[] }) {
@@ -298,50 +337,28 @@ function ProjectsTable({ projects }: { projects: ProjectContributions[] }) {
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-gray-100">
-              <th className="text-left py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                Project
-              </th>
-              <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                Commits
-              </th>
-              <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                PRs
-              </th>
-              <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                Reviews
-              </th>
-              <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                Issues
-              </th>
-              <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">
-                Total
-              </th>
+              <th className="text-left py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">Project</th>
+              <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">Commits</th>
+              <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">PRs</th>
+              <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">Reviews</th>
+              <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">Issues</th>
+              <th className="text-right py-3 px-4 text-xs font-semibold text-gray-500 uppercase tracking-wider">Total</th>
             </tr>
           </thead>
           <tbody>
             {visible.map((p) => (
-              <tr
-                key={p.id}
-                className="border-b border-gray-50 hover:bg-gray-50/50 transition-colors"
-              >
+              <tr key={p.id} className="border-b border-gray-50 hover:bg-gray-50/50 transition-colors">
                 <td className="py-3 px-4">
-                  <Link
-                    to={`/projects/${p.id}`}
-                    className="font-medium text-gray-900 hover:text-blue-600 transition-colors"
-                  >
+                  <Link to={`/projects/${p.id}`} className="font-medium text-gray-900 hover:text-blue-600 transition-colors">
                     {p.name}
                   </Link>
-                  <p className="text-xs text-gray-400 mt-0.5">
-                    {p.githubOrg}/{p.githubRepo}
-                  </p>
+                  <p className="text-xs text-gray-400 mt-0.5">{p.githubOrg}/{p.githubRepo}</p>
                 </td>
                 <td className="text-right py-3 px-4 tabular-nums text-gray-700">{p.commits}</td>
                 <td className="text-right py-3 px-4 tabular-nums text-gray-700">{p.prs}</td>
                 <td className="text-right py-3 px-4 tabular-nums text-gray-700">{p.reviews}</td>
                 <td className="text-right py-3 px-4 tabular-nums text-gray-700">{p.issues}</td>
-                <td className="text-right py-3 px-4 tabular-nums font-semibold text-gray-900">
-                  {p.total}
-                </td>
+                <td className="text-right py-3 px-4 tabular-nums font-semibold text-gray-900">{p.total}</td>
               </tr>
             ))}
           </tbody>
@@ -352,241 +369,222 @@ function ProjectsTable({ projects }: { projects: ProjectContributions[] }) {
           onClick={() => setExpanded(!expanded)}
           className="w-full text-center py-3 text-sm font-medium text-blue-600 hover:text-blue-800 transition-colors"
         >
-          {expanded
-            ? 'Show less'
-            : `Show all ${projects.length} projects`}
+          {expanded ? 'Show less' : `Show all ${projects.length} projects`}
         </button>
       )}
     </div>
   );
 }
 
+// ---------------------------------------------------------------------------
+// Roles section (kept from original page)
+// ---------------------------------------------------------------------------
+
 const ACRONYMS = new Set(['wg', 'tsc', 'sig', 'cd', 'ci', 'ai', 'ml', 'api']);
 const KNOWN_NAMES: Record<string, string> = {
-  kserve: 'KServe',
-  kubeflow: 'Kubeflow',
-  kubernetes: 'Kubernetes',
-  'kubernetes-sigs': 'Kubernetes SIGs',
-  argoproj: 'Argoproj',
-  istio: 'Istio',
-  knative: 'Knative',
-  'vllm-project': 'vLLM',
+  kserve: 'KServe', kubeflow: 'Kubeflow', kubernetes: 'Kubernetes',
+  'kubernetes-sigs': 'Kubernetes SIGs', argoproj: 'Argoproj',
+  istio: 'Istio', knative: 'Knative', 'vllm-project': 'vLLM',
 };
 
 function prettifyName(raw: string): string {
   if (KNOWN_NAMES[raw]) return KNOWN_NAMES[raw];
-  return raw
-    .replace(/[-_]/g, ' ')
-    .split(' ')
+  return raw.replace(/[-_]/g, ' ').split(' ')
     .map((w) => (ACRONYMS.has(w.toLowerCase()) ? w.toUpperCase() : w.charAt(0).toUpperCase() + w.slice(1)))
     .join(' ');
 }
 
 function formatRoleTitle(raw: string): string {
-  const cleaned = raw.replace(' - ', ' \u2014 ');
-  return cleaned
-    .replace(/[-_]/g, ' ')
-    .split(' ')
-    .map((w) => {
-      if (w === '\u2014') return w;
-      return ACRONYMS.has(w.toLowerCase()) ? w.toUpperCase() : w.charAt(0).toUpperCase() + w.slice(1);
-    })
+  return raw.replace(' - ', ' \u2014 ').replace(/[-_]/g, ' ').split(' ')
+    .map((w) => (w === '\u2014' ? w : ACRONYMS.has(w.toLowerCase()) ? w.toUpperCase() : w.charAt(0).toUpperCase() + w.slice(1)))
     .join(' ');
 }
 
 const PRESTIGE_ORDER: Record<string, number> = {
-  steering_committee: 1,
-  tsc_member: 2,
-  project_lead: 3,
-  wg_chair: 4,
-  wg_tech_lead: 5,
-  lead: 6,
-  sig_chair: 7,
-  sig_tech_lead: 8,
+  steering_committee: 1, tsc_member: 2, project_lead: 3,
+  wg_chair: 4, wg_tech_lead: 5, lead: 6, sig_chair: 7, sig_tech_lead: 8,
 };
 
 function getPrestige(positionType: string): number {
   return PRESTIGE_ORDER[positionType] ?? 20;
 }
 
-interface GovernanceSummaryGroup {
+interface UnifiedRole {
   title: string;
-  positionType: string;
-  byOrg: Map<string, string[]>;
+  org: string;
+  scope: string | null;
+  prestige: number;
+  voting: boolean;
+  category: 'leadership' | 'governance';
 }
 
-function buildGovernanceSummary(
-  maintainer: MaintainerRole[],
-  leadershipTitles: Set<string>,
-): GovernanceSummaryGroup[] {
-  const typeMap = new Map<string, GovernanceSummaryGroup>();
+function buildUnifiedRoles(maintainer: MaintainerRole[], leadership: LeadershipRole[]): Map<string, UnifiedRole[]> {
+  const byOrg = new Map<string, UnifiedRole[]>();
 
-  for (const r of maintainer) {
-    const key = r.positionTitle.toLowerCase();
-    if (leadershipTitles.has(key)) continue;
-
-    if (!typeMap.has(r.positionTitle)) {
-      typeMap.set(r.positionTitle, {
-        title: prettifyName(r.positionTitle),
-        positionType: r.positionType,
-        byOrg: new Map(),
-      });
-    }
-    const group = typeMap.get(r.positionTitle)!;
-    if (!group.byOrg.has(r.githubOrg)) {
-      group.byOrg.set(r.githubOrg, []);
-    }
-    group.byOrg.get(r.githubOrg)!.push(r.projectName);
+  for (const r of leadership) {
+    const org = r.communityOrg || 'Other';
+    if (!byOrg.has(org)) byOrg.set(org, []);
+    byOrg.get(org)!.push({
+      title: formatRoleTitle(r.roleTitle),
+      org,
+      scope: r.committeeName || null,
+      prestige: getPrestige(r.positionType),
+      voting: r.votingRights,
+      category: 'leadership',
+    });
   }
 
-  return Array.from(typeMap.values()).sort((a, b) => {
-    const aTotal = Array.from(a.byOrg.values()).reduce((s, p) => s + p.length, 0);
-    const bTotal = Array.from(b.byOrg.values()).reduce((s, p) => s + p.length, 0);
-    return bTotal - aTotal;
+  const leadershipTypesByOrg = new Set(leadership.map((l) => `${l.communityOrg}::${l.positionType}`));
+  for (const r of maintainer) {
+    if (leadershipTypesByOrg.has(`${r.githubOrg}::${r.positionType}`)) continue;
+    const org = r.githubOrg;
+    if (!byOrg.has(org)) byOrg.set(org, []);
+    byOrg.get(org)!.push({
+      title: prettifyName(r.positionTitle),
+      org,
+      scope: r.projectName,
+      prestige: getPrestige(r.positionType) + 10,
+      voting: false,
+      category: 'governance',
+    });
+  }
+
+  for (const roles of byOrg.values()) {
+    roles.sort((a, b) => a.prestige - b.prestige);
+  }
+
+  const sorted = Array.from(byOrg.entries()).sort(([, a], [, b]) => {
+    const aMin = Math.min(...a.map((r) => r.prestige));
+    const bMin = Math.min(...b.map((r) => r.prestige));
+    return aMin - bMin;
   });
+
+  return new Map(sorted);
 }
 
-function RolesSection({
-  maintainer,
-  leadership,
-}: {
-  maintainer: MaintainerRole[];
-  leadership: LeadershipRole[];
-}) {
-  if (maintainer.length === 0 && leadership.length === 0) return null;
-
-  const sortedLeadership = [...leadership].sort(
-    (a, b) => getPrestige(a.positionType) - getPrestige(b.positionType),
-  );
-
-  const leadershipTypesByOrg = new Set(
-    leadership.map((l) => `${l.communityOrg}::${l.positionType}`),
-  );
-  const leadershipTitles = new Set(
-    maintainer
-      .filter((m) => leadershipTypesByOrg.has(`${m.githubOrg}::${m.positionType}`))
-      .map((m) => m.positionTitle.toLowerCase()),
-  );
-
-  const governanceGroups = buildGovernanceSummary(maintainer, leadershipTitles);
+function RolePill({ role }: { role: UnifiedRole }) {
+  const isLeadership = role.category === 'leadership';
+  const isTop = role.prestige <= 3;
 
   return (
-    <section className="mb-8">
-      <h2 className="text-lg font-semibold text-gray-900 mb-4">
-        Community Standing
-      </h2>
-
-      {/* Leadership highlight cards */}
-      {sortedLeadership.length > 0 && (
-        <div className={`grid grid-cols-1 sm:grid-cols-2 ${sortedLeadership.length >= 4 ? 'lg:grid-cols-4' : sortedLeadership.length === 3 ? 'lg:grid-cols-3' : ''} gap-3 ${governanceGroups.length > 0 ? 'mb-4' : ''}`}>
-          {sortedLeadership.map((r, i) => {
-            const isTop = getPrestige(r.positionType) <= 3;
-            return (
-              <div
-                key={i}
-                className={`relative overflow-hidden rounded-xl p-4 ${
-                  isTop
-                    ? 'border border-amber-200 bg-gradient-to-br from-amber-50 via-amber-50/50 to-orange-50/60'
-                    : 'border border-amber-100/80 bg-gradient-to-br from-amber-50/40 via-white to-orange-50/20'
-                }`}
-              >
-                <div className="absolute top-3 right-3">
-                  <Crown className={`w-5 h-5 ${isTop ? 'text-amber-400/50' : 'text-amber-300/40'}`} />
-                </div>
-                <p className="text-sm font-bold text-gray-900 pr-6">
-                  {formatRoleTitle(r.roleTitle)}
-                </p>
-                {r.committeeName && (
-                  <p className="text-xs text-gray-500 mt-1">{r.committeeName}</p>
-                )}
-                <div className="flex items-center gap-2 mt-2.5">
-                  <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-                    isTop
-                      ? 'text-amber-800 bg-amber-200/70'
-                      : 'text-amber-700 bg-amber-100/70'
-                  }`}>
-                    {prettifyName(r.communityOrg)}
-                  </span>
-                  {r.votingRights && (
-                    <span className="text-[10px] font-bold text-amber-900 bg-amber-300/50 px-1.5 py-0.5 rounded-full tracking-wide">
-                      VOTING
-                    </span>
-                  )}
-                </div>
-              </div>
-            );
-          })}
+    <div className={`flex items-center gap-3 py-3 ${isLeadership ? '' : ''}`}>
+      <div className={`w-1 self-stretch rounded-full shrink-0 ${
+        isTop ? 'bg-amber-400' : isLeadership ? 'bg-amber-200' : 'bg-blue-200'
+      }`} />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className={`text-sm font-semibold ${isTop ? 'text-gray-900' : 'text-gray-800'}`}>
+            {role.title}
+          </span>
+          {isLeadership && (
+            <Crown className={`w-3.5 h-3.5 shrink-0 ${isTop ? 'text-amber-400' : 'text-amber-300'}`} />
+          )}
         </div>
-      )}
-
-      {/* Governance - role cards with project lists */}
-      {governanceGroups.length > 0 && (
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-          {governanceGroups.map((group, i) => {
-            const orgs = Array.from(group.byOrg.entries());
-            const projectCount = orgs.reduce((s, [, p]) => s + p.length, 0);
-            return (
-              <div
-                key={i}
-                className="bg-white rounded-xl border border-gray-100 shadow-sm p-4"
-              >
-                <div className="flex items-center justify-between mb-3">
-                  <span
-                    className={`text-xs font-semibold px-2 py-0.5 rounded-full ${
-                      group.positionType === 'reviewer'
-                        ? 'bg-blue-50 text-blue-700 border border-blue-200'
-                        : 'bg-indigo-50 text-indigo-700 border border-indigo-200'
-                    }`}
-                  >
-                    {group.title}
-                  </span>
-                  <span className="text-xs text-gray-400">
-                    {projectCount} {projectCount === 1 ? 'project' : 'projects'}
-                  </span>
-                </div>
-                <div className="space-y-3">
-                  {orgs.map(([org, projects]) => (
-                    <div key={org}>
-                      <p className="text-[10px] font-semibold uppercase tracking-wider text-gray-400 mb-1">
-                        {prettifyName(org)}
-                      </p>
-                      <div className="space-y-0.5">
-                        {projects.map((p, j) => (
-                          <p key={j} className="text-sm text-gray-700 leading-relaxed pl-2 border-l-2 border-gray-100">
-                            {p}
-                          </p>
-                        ))}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </section>
+        {role.scope && (
+          <p className="text-xs text-gray-500 mt-0.5">{role.scope}</p>
+        )}
+      </div>
+    </div>
   );
 }
+
+function RolesSection({ maintainer, leadership }: { maintainer: MaintainerRole[]; leadership: LeadershipRole[] }) {
+  if (maintainer.length === 0 && leadership.length === 0) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-8 text-center">
+        <Crown className="w-8 h-8 text-gray-200 mx-auto mb-3" />
+        <p className="text-sm text-gray-500">No leadership or governance roles yet</p>
+        <p className="text-xs text-gray-400 mt-1">Roles will appear here as you gain maintainer or leadership positions in upstream projects</p>
+      </div>
+    );
+  }
+
+  const rolesByOrg = buildUnifiedRoles(maintainer, leadership);
+  const totalRoles = Array.from(rolesByOrg.values()).reduce((s, r) => s + r.length, 0);
+
+  return (
+    <div>
+      {/* Summary strip */}
+      <div className="flex items-center gap-4 mb-5 text-xs text-gray-500">
+        <span><span className="font-semibold text-gray-700">{totalRoles}</span> {totalRoles === 1 ? 'role' : 'roles'} across <span className="font-semibold text-gray-700">{rolesByOrg.size}</span> {rolesByOrg.size === 1 ? 'organization' : 'organizations'}</span>
+      </div>
+
+      {/* Org groups */}
+      <div className="space-y-4">
+        {Array.from(rolesByOrg.entries()).map(([org, roles]) => (
+          <div key={org} className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
+            <div className="flex items-center justify-between mb-1">
+              <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">{prettifyName(org)}</h3>
+              <span className="text-[11px] text-gray-400">{roles.length} {roles.length === 1 ? 'role' : 'roles'}</span>
+            </div>
+            <div className="divide-y divide-gray-50">
+              {roles.map((role, i) => (
+                <RolePill key={`${role.title}-${role.scope}-${i}`} role={role} />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tabs
+// ---------------------------------------------------------------------------
+
+type TabId = 'overview' | 'activity' | 'governance';
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'activity', label: 'Activity' },
+  { id: 'governance', label: 'Governance' },
+];
+
+// ---------------------------------------------------------------------------
+// Main page component
+// ---------------------------------------------------------------------------
 
 export default function MyContributions() {
   const [searchParams, setSearchParams] = useSearchParams();
+  const [heatmapYear, setHeatmapYear] = useState<number | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const { user } = useAuth();
 
   const daysParam = searchParams.get('days');
-  const selectedDays =
-    daysParam !== null ? parseInt(daysParam, 10) : DEFAULT_PERIOD_DAYS;
+  const selectedDays = daysParam !== null ? parseInt(daysParam, 10) : DEFAULT_PERIOD_DAYS;
+  const activeTab = (searchParams.get('tab') as TabId) || 'overview';
+
+  const switchTab = (tab: TabId) => {
+    setSelectedDate(null);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('tab', tab);
+      return next;
+    });
+  };
+
+  const handlePeriodChange = (days: number) => {
+    setSelectedDate(null);
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set('days', days.toString());
+      return next;
+    });
+  };
 
   const { data, isLoading, isFetching, isPlaceholderData, error, refetch } = useQuery({
-    queryKey: ['my-contributions', selectedDays],
-    queryFn: () => fetchMyContributions(selectedDays),
+    queryKey: ['my-contributions', selectedDays, heatmapYear],
+    queryFn: () => fetchMyContributions(selectedDays, heatmapYear),
     refetchInterval: 60_000,
     placeholderData: (prev) => prev,
   });
 
-  const handlePeriodChange = (days: number) => {
-    setSearchParams({ days: days.toString() });
-  };
+  const { data: queueData, isLoading: queueLoading } = useQuery({
+    queryKey: ['my-action-queue'],
+    queryFn: fetchActionQueue,
+    refetchInterval: 120_000,
+  });
 
   if (error) {
     return (
@@ -612,53 +610,39 @@ export default function MyContributions() {
   const resolved = data as MyContributionsResolved | undefined;
   const isRefetching = isFetching && !isLoading;
 
-  const topProject = resolved?.projects?.[0];
-  const topType = resolved ? (() => {
-    const { commits, pullRequests, reviews, issues, total } = resolved.contributions;
-    const types = [
-      { label: 'Commits', count: commits },
-      { label: 'Pull Requests', count: pullRequests },
-      { label: 'Code Reviews', count: reviews },
-      { label: 'Issues', count: issues },
-    ];
-    const best = types.reduce((a, b) => (b.count > a.count ? b : a));
-    const pct = total > 0 ? ((best.count / total) * 100).toFixed(0) : '0';
-    return { label: best.label, count: best.count, pct };
-  })() : null;
-
   return (
-    <div className="bg-gray-50">
+    <div className="bg-gray-50 min-h-screen">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
         {/* Profile header */}
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-8">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
           <div className="flex items-center gap-4">
             {isLoading ? (
-              <Skeleton className="w-14 h-14 rounded-full" />
+              <Skeleton className="w-12 h-12 rounded-full" />
             ) : resolved?.profile.avatarUrl ? (
               <img
                 src={resolved.profile.avatarUrl}
                 alt={resolved.profile.name}
-                className="w-14 h-14 rounded-full border-2 border-white shadow-sm"
+                className="w-12 h-12 rounded-full border-2 border-white shadow-sm"
               />
             ) : (
-              <div className="w-14 h-14 rounded-full bg-gray-200 flex items-center justify-center">
-                <span className="text-xl font-bold text-gray-500">
-                  {resolved?.profile.name?.charAt(0) ?? '?'}
-                </span>
+              <div className="w-12 h-12 rounded-full bg-gray-200 flex items-center justify-center">
+                <span className="text-lg font-bold text-gray-500">{resolved?.profile.name?.charAt(0) ?? '?'}</span>
               </div>
             )}
             <div>
               {isLoading ? (
                 <>
-                  <Skeleton className="h-6 w-40 mb-1" />
-                  <Skeleton className="h-4 w-28" />
+                  <Skeleton className="h-6 w-36 mb-1" />
+                  <Skeleton className="h-4 w-24" />
                 </>
               ) : (
                 <>
-                  <h1 className="text-2xl font-bold text-gray-900">
-                    {resolved?.profile.name}
-                  </h1>
-                  <p className="text-sm text-gray-500 mt-0.5">My open source contributions</p>
+                  <div className="flex items-center gap-2.5">
+                    <h1 className="text-xl font-bold text-gray-900">{resolved?.profile.name}</h1>
+                    {resolved?.streak && (
+                      <StreakBadge current={resolved.streak.current} longest={resolved.streak.longest} todayActive={resolved.streak.todayActive} />
+                    )}
+                  </div>
                   <div className="flex items-center gap-3 mt-0.5">
                     {resolved?.profile.githubUsername && (
                       <a
@@ -672,210 +656,223 @@ export default function MyContributions() {
                       </a>
                     )}
                     {resolved?.profile.memberSince && (
-                      <span className="text-sm text-gray-400">
-                        Member since {resolved.profile.memberSince}
-                      </span>
+                      <span className="text-sm text-gray-400">Member since {resolved.profile.memberSince}</span>
                     )}
                   </div>
                 </>
               )}
             </div>
           </div>
-          <div className="flex items-center gap-3">
-            <PeriodSelector
-              selectedDays={selectedDays}
-              onSelect={handlePeriodChange}
-              isLoading={isRefetching}
-            />
-            {resolved && (
-              <div className="hidden sm:flex items-center gap-2 text-sm text-gray-500 bg-gray-100 px-3 py-1.5 rounded-lg">
-                <Calendar className="w-3.5 h-3.5" />
-                <span>
-                  {resolved.summary.periodStart === 'All time'
-                    ? 'All time'
-                    : `${resolved.summary.periodStart} – ${resolved.summary.periodEnd}`}
-                </span>
-              </div>
-            )}
+        </div>
+
+        {/* Tab bar */}
+        <div className="mb-6 border-b border-gray-200" role="tablist" aria-label="Profile sections">
+          <div className="flex gap-6">
+            {TABS.map((tab) => (
+              <button
+                key={tab.id}
+                role="tab"
+                aria-selected={activeTab === tab.id}
+                aria-controls={`tabpanel-${tab.id}`}
+                onClick={() => switchTab(tab.id)}
+                className={`pb-3 text-sm font-medium border-b-2 transition-colors ${
+                  activeTab === tab.id
+                    ? 'border-blue-600 text-blue-600'
+                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                }`}
+              >
+                {tab.label}
+              </button>
+            ))}
           </div>
         </div>
 
-        <div className={`transition-opacity duration-300 ${isPlaceholderData ? 'opacity-60' : ''}`}>
-          {/* Summary stats */}
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-            {isLoading ? (
-              <>
-                <StatCardSkeleton />
-                <StatCardSkeleton />
-                <StatCardSkeleton />
-                <StatCardSkeleton />
-              </>
-            ) : resolved ? (
-              <>
-                <StatCard
-                  label="My Contributions"
-                  value={resolved.summary.totalContributions.toLocaleString()}
-                  trend={resolved.trend}
-                  icon={GitCommit}
+        {/* Tab content */}
+        <div className={`transition-opacity duration-200 ${isPlaceholderData ? 'opacity-60' : ''}`}>
+          {activeTab === 'overview' && (
+            <div id="tabpanel-overview" role="tabpanel" aria-labelledby="tab-overview">
+              {/* Period selector */}
+              <div className="flex justify-end mb-4">
+                <PeriodSelector
+                  selectedDays={selectedDays}
+                  onSelect={handlePeriodChange}
+                  isLoading={isRefetching}
                 />
-                <StatCard
-                  label="Active Projects"
-                  value={resolved.summary.activeProjects}
-                  icon={FolderGit2}
-                />
-                <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-                  <div className="flex items-center gap-3 mb-2">
-                    <div className="p-2 bg-gray-50 rounded-lg">
-                      <Star className="w-4 h-4 text-gray-600" />
-                    </div>
-                    <span className="text-sm font-medium text-gray-600">Most Active In</span>
-                  </div>
-                  {topProject ? (
-                    <>
-                      <p className="text-lg font-bold text-gray-900 truncate" title={topProject.name}>
-                        {topProject.name}
-                      </p>
-                      <p className="text-xs text-gray-400 mt-0.5">
-                        {topProject.total.toLocaleString()} contributions
-                      </p>
-                    </>
-                  ) : (
-                    <p className="text-sm text-gray-400">No activity</p>
-                  )}
-                </div>
-                <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-                  <div className="flex items-center gap-3 mb-2">
-                    <div className="p-2 bg-gray-50 rounded-lg">
-                      <BarChart3 className="w-4 h-4 text-gray-600" />
-                    </div>
-                    <span className="text-sm font-medium text-gray-600">Top Type</span>
-                  </div>
-                  {topType && topType.count > 0 ? (
-                    <>
-                      <p className="text-lg font-bold text-gray-900 truncate" title={topType.label}>
-                        {topType.label}
-                      </p>
-                      <p className="text-xs text-gray-400 mt-0.5">
-                        {topType.count.toLocaleString()} ({topType.pct}% of total)
-                      </p>
-                    </>
-                  ) : (
-                    <p className="text-sm text-gray-400">No activity</p>
-                  )}
-                </div>
-              </>
-            ) : null}
-          </div>
-
-          {/* Activity over time */}
-          <section className="mb-8">
-            <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
-              <div className="flex items-center justify-between mb-4">
-                <h2 className="text-lg font-semibold text-gray-900">
-                  Activity Over Time
-                </h2>
-                <div className="flex items-center gap-4 text-[11px] text-gray-400">
-                  <span className="flex items-center gap-1.5">
-                    <span className="w-2.5 h-2.5 rounded-full bg-blue-500" />
-                    Commits
-                  </span>
-                  <span className="flex items-center gap-1.5">
-                    <span className="w-2.5 h-2.5 rounded-full bg-purple-500" />
-                    PRs
-                  </span>
-                  <span className="flex items-center gap-1.5">
-                    <span className="w-2.5 h-2.5 rounded-full bg-emerald-500" />
-                    Reviews
-                  </span>
-                  <span className="flex items-center gap-1.5">
-                    <span className="w-2.5 h-2.5 rounded-full bg-amber-500" />
-                    Issues
-                  </span>
-                </div>
               </div>
-              {isLoading ? (
-                <Skeleton className="h-56 w-full rounded-lg" />
-              ) : resolved ? (
-                <ActivityChart data={resolved.dailyActivity} />
-              ) : null}
-            </div>
-          </section>
 
-          {/* Contribution breakdown */}
-          <section className="mb-8">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-semibold text-gray-900">
-                Contribution Breakdown
-              </h2>
-            </div>
-            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
-              {isLoading ? (
-                <>
-                  <StatCardSkeleton />
-                  <StatCardSkeleton />
-                  <StatCardSkeleton />
-                  <StatCardSkeleton />
-                </>
-              ) : resolved ? (
-                <>
-                  <BreakdownCard
-                    title="Commits"
-                    count={resolved.contributions.commits}
-                    icon={GitCommit}
-                    color="text-blue-600"
-                    bgColor="bg-blue-50"
-                  />
-                  <BreakdownCard
-                    title="Pull Requests"
-                    count={resolved.contributions.pullRequests}
-                    icon={GitPullRequest}
-                    color="text-purple-600"
-                    bgColor="bg-purple-50"
-                  />
-                  <BreakdownCard
-                    title="Code Reviews"
-                    count={resolved.contributions.reviews}
-                    icon={MessageSquare}
-                    color="text-green-600"
-                    bgColor="bg-green-50"
-                  />
-                  <BreakdownCard
-                    title="Issues"
-                    count={resolved.contributions.issues}
-                    icon={AlertCircle}
-                    color="text-orange-600"
-                    bgColor="bg-orange-50"
-                  />
-                </>
-              ) : null}
-            </div>
-          </section>
+              {/* Action queue */}
+              <section className="mb-6">
+                {queueLoading ? (
+                  <ActionQueueSkeleton />
+                ) : queueData ? (
+                  <ActionQueue reviewRequests={queueData.reviewRequests} myOpenPRs={queueData.myOpenPRs} />
+                ) : null}
+              </section>
 
-          {/* Roles */}
-          {resolved && (
-            <RolesSection
-              maintainer={resolved.roles.maintainer}
-              leadership={resolved.roles.leadership}
-            />
+              {/* Pulse strip */}
+              <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-6">
+                {isLoading ? (
+                  <>
+                    <StatCardSkeleton />
+                    <StatCardSkeleton />
+                    <StatCardSkeleton />
+                    <StatCardSkeleton />
+                  </>
+                ) : resolved ? (
+                  <>
+                    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5 relative overflow-hidden">
+                      <div className="absolute -right-3 -top-3 w-16 h-16 rounded-full bg-blue-50/80" />
+                      <GitCommit className="w-5 h-5 text-blue-500 mb-3 relative z-10" />
+                      <p className="text-2xl font-bold text-gray-900 tabular-nums">{resolved.summary.totalContributions.toLocaleString()}</p>
+                      <div className="flex items-center gap-2 mt-1">
+                        <span className="text-xs text-gray-500">Contributions</span>
+                        {resolved.trend.direction !== 'flat' && (
+                          <span className={`text-[11px] font-semibold ${resolved.trend.direction === 'up' ? 'text-green-600' : 'text-red-500'}`}>
+                            {resolved.trend.direction === 'up' ? '+' : ''}{resolved.trend.changePercent}%
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5 relative overflow-hidden">
+                      <div className="absolute -right-3 -top-3 w-16 h-16 rounded-full bg-purple-50/80" />
+                      <FolderGit2 className="w-5 h-5 text-purple-500 mb-3 relative z-10" />
+                      <p className="text-2xl font-bold text-gray-900 tabular-nums">{resolved.summary.activeProjects}</p>
+                      <span className="text-xs text-gray-500 mt-1">Active Projects</span>
+                    </div>
+                    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5 relative overflow-hidden">
+                      <div className="absolute -right-3 -top-3 w-16 h-16 rounded-full bg-green-50/80" />
+                      <GitMerge className="w-5 h-5 text-green-500 mb-3 relative z-10" />
+                      <p className="text-2xl font-bold text-gray-900 tabular-nums">{resolved.mergeRate?.prsMerged.toLocaleString() ?? '—'}</p>
+                      <span className="text-xs text-gray-500 mt-1">PRs Merged</span>
+                    </div>
+                    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5 relative overflow-hidden">
+                      <div className="absolute -right-3 -top-3 w-16 h-16 rounded-full bg-amber-50/80" />
+                      <GitMerge className="w-5 h-5 text-amber-500 mb-3 relative z-10" />
+                      <p className="text-2xl font-bold text-gray-900 tabular-nums">{resolved.mergeRate ? `${resolved.mergeRate.mergeRate}%` : '—'}</p>
+                      <span className="text-xs text-gray-500 mt-1">Merge Rate</span>
+                    </div>
+                  </>
+                ) : null}
+              </div>
+
+              {/* Activity over time */}
+              <section className="mb-6">
+                <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+                  <div className="flex items-center justify-between mb-4">
+                    <h2 className="text-sm font-semibold text-gray-900">Activity Over Time</h2>
+                    <div className="flex items-center gap-4 text-[11px] text-gray-400">
+                      <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-full bg-blue-500" />Commits</span>
+                      <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-full bg-purple-500" />PRs</span>
+                      <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-full bg-emerald-500" />Reviews</span>
+                      <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-full bg-amber-500" />Issues</span>
+                    </div>
+                  </div>
+                  {isLoading ? (
+                    <Skeleton className="h-56 w-full rounded-lg" />
+                  ) : resolved ? (
+                    <ActivityChart data={resolved.dailyActivity} />
+                  ) : null}
+                </div>
+              </section>
+
+              {/* Top projects compact bar */}
+              {!isLoading && resolved && resolved.projects.length > 0 && (
+                <section className="mb-6">
+                  <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+                    <h2 className="text-sm font-semibold text-gray-900 mb-4">Top Projects</h2>
+                    <div className="space-y-2.5">
+                      {resolved.projects.slice(0, 5).map((p) => {
+                        const maxTotal = resolved.projects[0].total;
+                        const pct = maxTotal > 0 ? (p.total / maxTotal) * 100 : 0;
+                        return (
+                          <div key={p.id} className="flex items-center gap-3">
+                            <Link to={`/projects/${p.id}`} className="text-sm text-gray-700 hover:text-blue-600 transition-colors w-36 truncate shrink-0 font-medium">
+                              {p.name}
+                            </Link>
+                            <div className="flex-1 h-5 bg-gray-50 rounded-full overflow-hidden">
+                              <div
+                                className="h-full bg-blue-100 rounded-full flex items-center pl-2"
+                                style={{ width: `${Math.max(pct, 8)}%` }}
+                              >
+                                <span className="text-[11px] font-semibold text-blue-700 tabular-nums">{p.total}</span>
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </section>
+              )}
+
+            </div>
           )}
 
-          {/* My projects */}
-          <section className="mb-8">
-            <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
-              <h2 className="text-lg font-semibold text-gray-900 mb-4">
-                My Projects
-              </h2>
+          {activeTab === 'activity' && (
+            <div id="tabpanel-activity" role="tabpanel" aria-labelledby="tab-activity">
+              {/* Contribution heatmap */}
               {isLoading ? (
-                <div className="space-y-3">
-                  {Array.from({ length: 4 }, (_, i) => (
-                    <Skeleton key={i} className="h-12 w-full rounded" />
-                  ))}
+                <Skeleton className="h-52 w-full rounded-xl mb-6" />
+              ) : resolved?.heatmap ? (
+                <div className="mb-6">
+                  <ContributionHeatmap
+                    data={resolved.heatmap}
+                    streak={{ current: resolved.streak.current, longest: resolved.streak.longest }}
+                    onYearChange={setHeatmapYear}
+                    onDateSelect={setSelectedDate}
+                    selectedDate={selectedDate}
+                    memberSince={resolved.profile.memberSince}
+                  />
+                </div>
+              ) : null}
+
+              {/* Recent activity (full width) */}
+              {isLoading ? (
+                <div className="mb-8"><Skeleton className="h-80 w-full rounded-xl" /></div>
+              ) : resolved ? (
+                <div className="mb-8">
+                  <RecentActivityFeed
+                    items={resolved.recentActivity}
+                    dateFilter={selectedDate}
+                    onClearDateFilter={() => setSelectedDate(null)}
+                  />
+                </div>
+              ) : null}
+
+              {/* My projects */}
+              <section className="mb-8">
+                <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+                  <h2 className="text-lg font-semibold text-gray-900 mb-4">My Projects</h2>
+                  {isLoading ? (
+                    <div className="space-y-3">
+                      {Array.from({ length: 4 }, (_, i) => (
+                        <Skeleton key={i} className="h-12 w-full rounded" />
+                      ))}
+                    </div>
+                  ) : resolved ? (
+                    <ProjectsTable projects={resolved.projects} />
+                  ) : null}
+                </div>
+              </section>
+
+            </div>
+          )}
+
+          {activeTab === 'governance' && (
+            <div id="tabpanel-governance" role="tabpanel" aria-labelledby="tab-governance">
+              {isLoading ? (
+                <div className="space-y-4">
+                  <Skeleton className="h-24 w-full rounded-xl" />
+                  <Skeleton className="h-24 w-full rounded-xl" />
                 </div>
               ) : resolved ? (
-                <ProjectsTable projects={resolved.projects} />
+                <RolesSection
+                  maintainer={resolved.roles.maintainer}
+                  leadership={resolved.roles.leadership}
+                />
               ) : null}
             </div>
-          </section>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Redesign the /me page (dev-only) into a daily-driver contributor home:

Overview tab:
- Period-scoped stat cards (contributions, projects, PRs merged, merge rate)
- Activity over time stacked area chart
- Top 5 projects horizontal bar
- Action queue showing open PRs and review requests (live GitHub GraphQL)

Activity tab:
- Interactive contribution heatmap (click day to filter table)
- Filterable activity table with type chips and project dropdown
- Full projects table with per-project breakdown

Governance tab:
- Unified role list grouped by organization
- Leadership positions with prestige ordering

Also adds:
- Streak badge with tiered visuals and tooltip (weekends excluded)
- Heatmap year selector dropdown
- Collection worker upsert for future line stat enrichment
- GET /api/metrics/me/action-queue endpoint with 2-min cache