### PR TITLE
feat: add generic bulk team member sync API and make GitHub org sync …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ coverage/
 .cache/
 access-stats-*.txt
 
+# Credentials / service account keys
+gcp-sa-key.json
+*-sa-key.json
+
 # Database
 *.sqlite
 *.sqlite-shm

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -593,21 +593,17 @@ app.post<{
     }
 
     const deactivationSources = [source, ...replacesSources];
-    const incomingByUsername = new Map<string, typeof people[0]>();
-    const incomingByEmail = new Map<string, typeof people[0]>();
+    const seenUsernames = new Set<string>();
     const duplicateUsernames: string[] = [];
 
     for (const person of people) {
       if (!person.name || (!person.email && !person.githubUsername)) continue;
       if (person.githubUsername) {
         const lower = person.githubUsername.toLowerCase();
-        if (incomingByUsername.has(lower)) {
+        if (seenUsernames.has(lower)) {
           duplicateUsernames.push(person.githubUsername);
         }
-        incomingByUsername.set(lower, person);
-      }
-      if (person.email) {
-        incomingByEmail.set(person.email.toLowerCase(), person);
+        seenUsernames.add(lower);
       }
     }
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -355,7 +355,7 @@ app.post<{
           UPDATE contributions
           SET team_member_id = ${newMember.id}
           WHERE team_member_id IS NULL
-            AND (metadata #>> '{}')::jsonb->>'author' = ${githubUsername}
+            AND LOWER((metadata #>> '{}')::jsonb->>'author') = LOWER(${githubUsername})
         `) as unknown as { count: number; rowCount?: number };
         relinked.contributions = contribResult.count ?? contribResult.rowCount ?? 0;
 
@@ -363,7 +363,7 @@ app.post<{
           UPDATE maintainer_status
           SET team_member_id = ${newMember.id}
           WHERE team_member_id IS NULL
-            AND github_username = ${githubUsername}
+            AND LOWER(github_username) = LOWER(${githubUsername})
         `) as unknown as { count: number; rowCount?: number };
         relinked.maintainerStatus = msResult.count ?? msResult.rowCount ?? 0;
 
@@ -371,7 +371,7 @@ app.post<{
           UPDATE leadership_positions
           SET team_member_id = ${newMember.id}
           WHERE team_member_id IS NULL
-            AND github_username = ${githubUsername}
+            AND LOWER(github_username) = LOWER(${githubUsername})
         `) as unknown as { count: number; rowCount?: number };
         relinked.leadershipPositions = lpResult.count ?? lpResult.rowCount ?? 0;
 
@@ -560,6 +560,193 @@ app.post<{
     reply.status(500);
     return {
       error: 'Failed to trigger team sync',
+      message: (error as Error).message,
+    };
+  }
+});
+
+// Bulk team member sync from external source
+app.post<{
+  Body: {
+    source: string;
+    replacesSources?: string[];
+    people: Array<{
+      name: string;
+      email?: string;
+      githubUsername?: string;
+      employeeId?: string;
+      department?: string;
+      role?: string;
+    }>;
+  };
+}>('/api/admin/team-members/sync', { preHandler: [requireAdmin] }, async (request, reply) => {
+  try {
+    const { source, replacesSources = [], people } = request.body;
+
+    if (!source || typeof source !== 'string') {
+      reply.status(400);
+      return { error: 'source is required (string label for this sync provider)' };
+    }
+    if (!Array.isArray(people) || people.length === 0) {
+      reply.status(400);
+      return { error: 'people array is required and must not be empty' };
+    }
+
+    const deactivationSources = [source, ...replacesSources];
+    const incomingByUsername = new Map<string, typeof people[0]>();
+    const incomingByEmail = new Map<string, typeof people[0]>();
+    const duplicateUsernames: string[] = [];
+
+    for (const person of people) {
+      if (!person.name || (!person.email && !person.githubUsername)) continue;
+      if (person.githubUsername) {
+        const lower = person.githubUsername.toLowerCase();
+        if (incomingByUsername.has(lower)) {
+          duplicateUsernames.push(person.githubUsername);
+        }
+        incomingByUsername.set(lower, person);
+      }
+      if (person.email) {
+        incomingByEmail.set(person.email.toLowerCase(), person);
+      }
+    }
+
+    if (duplicateUsernames.length > 0) {
+      logger.warn(`Bulk sync: duplicate GitHub usernames in payload`, { duplicateUsernames });
+    }
+
+    const existingMembers = await db.query.teamMembers.findMany();
+    const existingByUsername = new Map<string, typeof existingMembers[0]>();
+    const existingByEmail = new Map<string, typeof existingMembers[0]>();
+    for (const m of existingMembers) {
+      if (m.githubUsername) existingByUsername.set(m.githubUsername.toLowerCase(), m);
+      if (m.primaryEmail) existingByEmail.set(m.primaryEmail.toLowerCase(), m);
+    }
+
+    let upserted = 0;
+    let inserted = 0;
+    const processedIds = new Set<string>();
+    const incomingUsernames = new Set<string>();
+
+    for (const person of people) {
+      if (!person.name || (!person.email && !person.githubUsername)) continue;
+      if (person.githubUsername) incomingUsernames.add(person.githubUsername.toLowerCase());
+
+      const existing =
+        (person.githubUsername ? existingByUsername.get(person.githubUsername.toLowerCase()) : undefined) ??
+        (person.email ? existingByEmail.get(person.email.toLowerCase()) : undefined);
+
+      if (existing) {
+        await db.update(teamMembers).set({
+          name: person.name,
+          primaryEmail: person.email || existing.primaryEmail,
+          githubUsername: person.githubUsername || existing.githubUsername,
+          employeeId: person.employeeId || existing.employeeId,
+          department: person.department || existing.department,
+          role: person.role || existing.role,
+          source,
+          isActive: true,
+          endDate: null,
+          updatedAt: new Date(),
+        }).where(eq(teamMembers.id, existing.id));
+        processedIds.add(existing.id);
+        upserted++;
+      } else {
+        try {
+          const [newMember] = await db.insert(teamMembers).values({
+            name: person.name,
+            primaryEmail: person.email || null,
+            githubUsername: person.githubUsername || null,
+            employeeId: person.employeeId || null,
+            department: person.department || null,
+            role: person.role || null,
+            source,
+            isActive: true,
+          }).returning();
+          processedIds.add(newMember.id);
+          inserted++;
+        } catch (insertError) {
+          if ((insertError as any).code === '23505') {
+            logger.warn(`Bulk sync: skipping duplicate for ${person.name} (${person.email})`, { insertError });
+          } else {
+            throw insertError;
+          }
+        }
+      }
+    }
+
+    // Deactivate stale rows from owned sources
+    let deactivated = 0;
+    for (const m of existingMembers) {
+      if (!m.isActive) continue;
+      if (processedIds.has(m.id)) continue;
+      if (!m.source || !deactivationSources.includes(m.source)) continue;
+      if (m.githubUsername && incomingUsernames.has(m.githubUsername.toLowerCase())) continue;
+
+      await db.update(teamMembers).set({
+        isActive: false,
+        endDate: new Date().toISOString().split('T')[0],
+        updatedAt: new Date(),
+      }).where(eq(teamMembers.id, m.id));
+      deactivated++;
+    }
+
+    // Relink orphaned contributions/maintainer/leadership for new members
+    let totalRelinked = 0;
+    if (inserted > 0) {
+      try {
+        const newMembers = await db.query.teamMembers.findMany({
+          where: and(eq(teamMembers.source, source), eq(teamMembers.isActive, true)),
+        });
+        for (const m of newMembers) {
+          if (!m.githubUsername || !processedIds.has(m.id)) continue;
+          const contribResult = await db.execute(sql`
+            UPDATE contributions SET team_member_id = ${m.id}
+            WHERE team_member_id IS NULL
+              AND LOWER((metadata #>> '{}')::jsonb->>'author') = LOWER(${m.githubUsername})
+          `) as unknown as { rowCount?: number };
+          const msResult = await db.execute(sql`
+            UPDATE maintainer_status SET team_member_id = ${m.id}
+            WHERE team_member_id IS NULL AND LOWER(github_username) = LOWER(${m.githubUsername})
+          `) as unknown as { rowCount?: number };
+          const lpResult = await db.execute(sql`
+            UPDATE leadership_positions SET team_member_id = ${m.id}
+            WHERE team_member_id IS NULL AND LOWER(github_username) = LOWER(${m.githubUsername})
+          `) as unknown as { rowCount?: number };
+          totalRelinked += (contribResult.rowCount ?? 0) + (msResult.rowCount ?? 0) + (lpResult.rowCount ?? 0);
+        }
+      } catch (relinkError) {
+        logger.warn('Bulk sync: relink failed (non-fatal)', { error: relinkError });
+      }
+    }
+
+    // Queue governance + leadership refresh if new members were added
+    if (inserted > 0 || totalRelinked > 0) {
+      try {
+        const { CollectionScheduler } = await import('./jobs/scheduler.js');
+        const scheduler = new CollectionScheduler();
+        await scheduler.triggerGovernanceRefresh();
+        await scheduler.triggerLeadershipRefresh();
+      } catch (refreshError) {
+        logger.warn('Bulk sync: governance/leadership refresh queue failed (non-fatal)', { error: refreshError });
+      }
+    }
+
+    logger.info(`Bulk team sync complete`, { source, upserted, inserted, deactivated, relinked: totalRelinked });
+
+    return {
+      success: true,
+      source,
+      upserted,
+      inserted,
+      deactivated,
+      relinked: totalRelinked,
+    };
+  } catch (error) {
+    logger.error('Error in bulk team sync', { error });
+    reply.status(500);
+    return {
+      error: 'Bulk team sync failed',
       message: (error as Error).message,
     };
   }

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -14,6 +14,7 @@ import { teamMembers, projects } from './shared/database/schema.js';
 import { eq, sql, count, and } from 'drizzle-orm';
 import { registerIdentityMiddleware } from './shared/middleware/identity.js';
 import { requireAdmin } from './shared/middleware/admin-guard.js';
+import { z } from 'zod';
 
 // Validate configuration on startup
 try {
@@ -566,47 +567,41 @@ app.post<{
 });
 
 // Bulk team member sync from external source
-app.post<{
-  Body: {
-    source: string;
-    replacesSources?: string[];
-    people: Array<{
-      name: string;
-      email?: string;
-      githubUsername?: string;
-      employeeId?: string;
-      department?: string;
-      role?: string;
-    }>;
-  };
-}>('/api/admin/team-members/sync', { preHandler: [requireAdmin] }, async (request, reply) => {
+const bulkSyncSchema = z.object({
+  source: z.string().min(1),
+  replacesSources: z.array(z.string()).optional().default([]),
+  people: z.array(z.object({
+    name: z.string().min(1),
+    email: z.string().optional(),
+    githubUsername: z.string().optional(),
+    employeeId: z.string().optional(),
+    department: z.string().optional(),
+    role: z.string().optional(),
+  }).refine(p => p.email || p.githubUsername, {
+    message: 'Each person needs at least email or githubUsername',
+  })).min(1),
+});
+
+app.post('/api/admin/team-members/sync', { preHandler: [requireAdmin] }, async (request, reply) => {
   try {
-    const { source, replacesSources = [], people } = request.body;
-
-    if (!source || typeof source !== 'string') {
+    const parsed = bulkSyncSchema.safeParse(request.body);
+    if (!parsed.success) {
       reply.status(400);
-      return { error: 'source is required (string label for this sync provider)' };
-    }
-    if (!Array.isArray(people) || people.length === 0) {
-      reply.status(400);
-      return { error: 'people array is required and must not be empty' };
+      return { error: 'Invalid request body', details: parsed.error.flatten() };
     }
 
+    const { source, replacesSources, people } = parsed.data;
     const deactivationSources = [source, ...replacesSources];
+
     const seenUsernames = new Set<string>();
     const duplicateUsernames: string[] = [];
-
     for (const person of people) {
-      if (!person.name || (!person.email && !person.githubUsername)) continue;
       if (person.githubUsername) {
         const lower = person.githubUsername.toLowerCase();
-        if (seenUsernames.has(lower)) {
-          duplicateUsernames.push(person.githubUsername);
-        }
+        if (seenUsernames.has(lower)) duplicateUsernames.push(person.githubUsername);
         seenUsernames.add(lower);
       }
     }
-
     if (duplicateUsernames.length > 0) {
       logger.warn(`Bulk sync: duplicate GitHub usernames in payload`, { duplicateUsernames });
     }
@@ -623,100 +618,95 @@ app.post<{
     let inserted = 0;
     const processedIds = new Set<string>();
     const incomingUsernames = new Set<string>();
+    const newlyInserted: Array<{ id: string; githubUsername: string }> = [];
+    let deactivated = 0;
+    let totalRelinked = 0;
 
-    for (const person of people) {
-      if (!person.name || (!person.email && !person.githubUsername)) continue;
-      if (person.githubUsername) incomingUsernames.add(person.githubUsername.toLowerCase());
+    await db.transaction(async (tx) => {
+      for (const person of people) {
+        if (person.githubUsername) incomingUsernames.add(person.githubUsername.toLowerCase());
 
-      const existing =
-        (person.githubUsername ? existingByUsername.get(person.githubUsername.toLowerCase()) : undefined) ??
-        (person.email ? existingByEmail.get(person.email.toLowerCase()) : undefined);
+        const existing =
+          (person.githubUsername ? existingByUsername.get(person.githubUsername.toLowerCase()) : undefined) ??
+          (person.email ? existingByEmail.get(person.email.toLowerCase()) : undefined);
 
-      if (existing) {
-        await db.update(teamMembers).set({
-          name: person.name,
-          primaryEmail: person.email || existing.primaryEmail,
-          githubUsername: person.githubUsername || existing.githubUsername,
-          employeeId: person.employeeId || existing.employeeId,
-          department: person.department || existing.department,
-          role: person.role || existing.role,
-          source,
-          isActive: true,
-          endDate: null,
-          updatedAt: new Date(),
-        }).where(eq(teamMembers.id, existing.id));
-        processedIds.add(existing.id);
-        upserted++;
-      } else {
-        try {
-          const [newMember] = await db.insert(teamMembers).values({
+        if (existing) {
+          await tx.update(teamMembers).set({
             name: person.name,
-            primaryEmail: person.email || null,
-            githubUsername: person.githubUsername || null,
-            employeeId: person.employeeId || null,
-            department: person.department || null,
-            role: person.role || null,
+            primaryEmail: person.email || existing.primaryEmail,
+            githubUsername: person.githubUsername || existing.githubUsername,
+            employeeId: person.employeeId || existing.employeeId,
+            department: person.department || existing.department,
+            role: person.role || existing.role,
             source,
             isActive: true,
-          }).returning();
-          processedIds.add(newMember.id);
-          inserted++;
-        } catch (insertError) {
-          if ((insertError as any).code === '23505') {
-            logger.warn(`Bulk sync: skipping duplicate for ${person.name} (${person.email})`, { insertError });
-          } else {
-            throw insertError;
+            endDate: null,
+            updatedAt: new Date(),
+          }).where(eq(teamMembers.id, existing.id));
+          processedIds.add(existing.id);
+          upserted++;
+        } else {
+          try {
+            const [newMember] = await tx.insert(teamMembers).values({
+              name: person.name,
+              primaryEmail: person.email || null,
+              githubUsername: person.githubUsername || null,
+              employeeId: person.employeeId || null,
+              department: person.department || null,
+              role: person.role || null,
+              source,
+              isActive: true,
+            }).returning();
+            processedIds.add(newMember.id);
+            inserted++;
+            if (newMember.githubUsername) {
+              newlyInserted.push({ id: newMember.id, githubUsername: newMember.githubUsername });
+            }
+          } catch (insertError) {
+            if ((insertError as any).code === '23505') {
+              logger.warn(`Bulk sync: skipping duplicate for ${person.name} (${person.email})`, { insertError });
+            } else {
+              throw insertError;
+            }
           }
         }
       }
-    }
 
-    // Deactivate stale rows from owned sources
-    let deactivated = 0;
-    for (const m of existingMembers) {
-      if (!m.isActive) continue;
-      if (processedIds.has(m.id)) continue;
-      if (!m.source || !deactivationSources.includes(m.source)) continue;
-      if (m.githubUsername && incomingUsernames.has(m.githubUsername.toLowerCase())) continue;
+      // Deactivate stale rows from owned sources
+      for (const m of existingMembers) {
+        if (!m.isActive) continue;
+        if (processedIds.has(m.id)) continue;
+        if (!m.source || !deactivationSources.includes(m.source)) continue;
+        if (m.githubUsername && incomingUsernames.has(m.githubUsername.toLowerCase())) continue;
 
-      await db.update(teamMembers).set({
-        isActive: false,
-        endDate: new Date().toISOString().split('T')[0],
-        updatedAt: new Date(),
-      }).where(eq(teamMembers.id, m.id));
-      deactivated++;
-    }
-
-    // Relink orphaned contributions/maintainer/leadership for new members
-    let totalRelinked = 0;
-    if (inserted > 0) {
-      try {
-        const newMembers = await db.query.teamMembers.findMany({
-          where: and(eq(teamMembers.source, source), eq(teamMembers.isActive, true)),
-        });
-        for (const m of newMembers) {
-          if (!m.githubUsername || !processedIds.has(m.id)) continue;
-          const contribResult = await db.execute(sql`
-            UPDATE contributions SET team_member_id = ${m.id}
-            WHERE team_member_id IS NULL
-              AND LOWER((metadata #>> '{}')::jsonb->>'author') = LOWER(${m.githubUsername})
-          `) as unknown as { rowCount?: number };
-          const msResult = await db.execute(sql`
-            UPDATE maintainer_status SET team_member_id = ${m.id}
-            WHERE team_member_id IS NULL AND LOWER(github_username) = LOWER(${m.githubUsername})
-          `) as unknown as { rowCount?: number };
-          const lpResult = await db.execute(sql`
-            UPDATE leadership_positions SET team_member_id = ${m.id}
-            WHERE team_member_id IS NULL AND LOWER(github_username) = LOWER(${m.githubUsername})
-          `) as unknown as { rowCount?: number };
-          totalRelinked += (contribResult.rowCount ?? 0) + (msResult.rowCount ?? 0) + (lpResult.rowCount ?? 0);
-        }
-      } catch (relinkError) {
-        logger.warn('Bulk sync: relink failed (non-fatal)', { error: relinkError });
+        await tx.update(teamMembers).set({
+          isActive: false,
+          endDate: new Date().toISOString().split('T')[0],
+          updatedAt: new Date(),
+        }).where(eq(teamMembers.id, m.id));
+        deactivated++;
       }
-    }
 
-    // Queue governance + leadership refresh if new members were added
+      // Relink orphaned contributions/maintainer/leadership for newly inserted members
+      for (const m of newlyInserted) {
+        const contribResult = await tx.execute(sql`
+          UPDATE contributions SET team_member_id = ${m.id}
+          WHERE team_member_id IS NULL
+            AND LOWER((metadata #>> '{}')::jsonb->>'author') = LOWER(${m.githubUsername})
+        `) as unknown as { rowCount?: number };
+        const msResult = await tx.execute(sql`
+          UPDATE maintainer_status SET team_member_id = ${m.id}
+          WHERE team_member_id IS NULL AND LOWER(github_username) = LOWER(${m.githubUsername})
+        `) as unknown as { rowCount?: number };
+        const lpResult = await tx.execute(sql`
+          UPDATE leadership_positions SET team_member_id = ${m.id}
+          WHERE team_member_id IS NULL AND LOWER(github_username) = LOWER(${m.githubUsername})
+        `) as unknown as { rowCount?: number };
+        totalRelinked += (contribResult.rowCount ?? 0) + (msResult.rowCount ?? 0) + (lpResult.rowCount ?? 0);
+      }
+    });
+
+    // Queue governance + leadership refresh if new members were added (outside transaction)
     if (inserted > 0 || totalRelinked > 0) {
       try {
         const { CollectionScheduler } = await import('./jobs/scheduler.js');

--- a/backend/src/jobs/scheduler.ts
+++ b/backend/src/jobs/scheduler.ts
@@ -113,7 +113,9 @@ export class CollectionScheduler {
     });
 
     // Weekly team sync at 1 AM UTC on Mondays (before governance refresh at 3 AM)
+    // Only runs when GITHUB_TEAM_ORG is configured (opt-in)
     this.weeklyTeamSyncSchedule = cron.schedule('0 1 * * 1', async () => {
+      if (config.githubTeamOrgs.length === 0) return;
       logger.info('Triggering weekly team sync from GitHub org');
       await this.triggerTeamSync();
     });
@@ -459,6 +461,11 @@ export class CollectionScheduler {
     const orgs = orgFilter
       ? [orgFilter]
       : config.githubTeamOrgs;
+
+    if (orgs.length === 0) {
+      logger.info('Team sync skipped: no GitHub orgs configured (GITHUB_TEAM_ORG is empty)');
+      return [];
+    }
 
     logger.info(`Triggering team sync for ${orgs.length} org(s)`, { orgs, trigger });
 

--- a/backend/src/modules/identity/resolver.ts
+++ b/backend/src/modules/identity/resolver.ts
@@ -39,7 +39,7 @@ export class IdentityResolver {
   ): Promise<ResolvedIdentity | null> {
     try {
       const member = await db.query.teamMembers.findFirst({
-        where: eq(teamMembers.githubUsername, githubUsername),
+        where: sql`LOWER(${teamMembers.githubUsername}) = LOWER(${githubUsername})`,
       });
 
       if (member) {

--- a/backend/src/shared/config/index.ts
+++ b/backend/src/shared/config/index.ts
@@ -25,8 +25,8 @@ export const config = {
 
   // GitHub org team sync (personal PAT with read:org)
   githubTeamToken: process.env.GITHUB_TEAM_TOKEN || process.env.GITHUB_TOKEN || '',
-  // Comma-separated list of GitHub orgs to sync team members from
-  githubTeamOrgs: (process.env.GITHUB_TEAM_ORG || 'opendatahub-io')
+  // Comma-separated list of GitHub orgs to sync team members from (opt-in: leave empty to disable)
+  githubTeamOrgs: (process.env.GITHUB_TEAM_ORG || '')
     .split(',')
     .map(s => s.trim())
     .filter(Boolean),


### PR DESCRIPTION
…opt-in

Add POST /api/admin/team-members/sync endpoint that accepts a team roster from any external source and upserts team_members by GitHub username (case-insensitive). Supports source-scoped deactivation, replacesSources for migration between sync providers, orphan relinking, and automatic governance/leadership refresh.

Also:
- Fix case-insensitive GitHub username matching in IdentityResolver
- Fix case-insensitive matching in relink SQL (contributions, maintainer, leadership)
- Make GITHUB_TEAM_ORG opt-in (default empty instead of opendatahub-io)
- Guard scheduler cron and triggerTeamSync when no orgs configured
- Gitignore service account key files