### PR TITLE
deploy(prod): add roster-sync-service to ADMIN_USERS and disable GitHub org sync

### DIFF
--- a/deploy/openshift/overlays/prod/configmap-patch.yaml
+++ b/deploy/openshift/overlays/prod/configmap-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: upstream-pulse-config
+  namespace: upstream-pulse
+data:
+  ADMIN_USERS: "admin,roster-sync-service"
+  GITHUB_TEAM_ORG: ""

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -15,6 +15,10 @@ resources:
 - postgres-backup-cronjob.yaml
 - postgres-backup-monitor-cronjob.yaml
 - postgres-restore-test-cronjob.yaml
+
+patches:
+- path: configmap-patch.yaml
+
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
   newTag: 2bccd51


### PR DESCRIPTION
Prod configmap overlay:
- ADMIN_USERS includes roster-sync-service for org-pulse roster push
- GITHUB_TEAM_ORG set to empty to disable old GitHub org sync