### PR TITLE
chore: add dipgupta to prod admin users

### DIFF
--- a/deploy/openshift/overlays/preprod/configmap-patch.yaml
+++ b/deploy/openshift/overlays/preprod/configmap-patch.yaml
@@ -4,5 +4,5 @@ metadata:
   name: upstream-pulse-config
   namespace: upstream-pulse
 data:
-  ADMIN_USERS: "admin,roster-sync-service"
+  ADMIN_USERS: "admin,roster-sync-service,dipgupta"
   GITHUB_TEAM_ORG: ""

--- a/deploy/openshift/overlays/prod/configmap-patch.yaml
+++ b/deploy/openshift/overlays/prod/configmap-patch.yaml
@@ -4,5 +4,5 @@ metadata:
   name: upstream-pulse-config
   namespace: upstream-pulse
 data:
-  ADMIN_USERS: "admin,roster-sync-service"
+  ADMIN_USERS: "admin,roster-sync-service,dipgupta"
   GITHUB_TEAM_ORG: ""


### PR DESCRIPTION
## Summary
- Adds `dipgupta` to `ADMIN_USERS` in the prod ConfigMap overlay so that this user has admin access to upstream-pulse in production (e.g. Add Project button, admin API endpoints).

## Test plan
- [ ] Verify ArgoCD syncs the updated ConfigMap after merge
- [ ] Confirm `dipgupta` can access admin features in the upstream-pulse prod UI