### PR TITLE
fix: resolve @org/team CODEOWNERS refs via comment-header team mappings

### DIFF
--- a/backend/src/modules/collection/codeowners-parser.ts
+++ b/backend/src/modules/collection/codeowners-parser.ts
@@ -94,8 +94,9 @@ export class CodeownersParser {
     const userPaths = new Map<string, Set<string>>();
 
     const addUser = (username: string, pattern: string) => {
-      if (!userPaths.has(username)) userPaths.set(username, new Set());
-      userPaths.get(username)!.add(pattern);
+      const paths = userPaths.get(username) ?? new Set<string>();
+      paths.add(pattern);
+      userPaths.set(username, paths);
     };
 
     for (const rawLine of content.split('\n')) {

--- a/backend/src/modules/collection/codeowners-parser.ts
+++ b/backend/src/modules/collection/codeowners-parser.ts
@@ -2,10 +2,15 @@
  * CODEOWNERS Parser
  *
  * Parses GitHub-native CODEOWNERS files to extract per-user maintainer entries.
- * Only @username references are captured — @org/team references are skipped
- * because resolving team membership requires `read:org` scope on external orgs.
  *
- * Checks `.github/CODEOWNERS` first, then root `CODEOWNERS`.
+ * Handles two owner formats:
+ *   1. @username — captured directly
+ *   2. @org/team — resolved via comment headers when the repo embeds a
+ *      team-member mapping in comments (e.g. `# org/team : user1, user2`).
+ *      This covers repos where GitHub team visibility is private and
+ *      maintainers are listed in comments by convention.
+ *
+ * Checks `.github/CODEOWNERS`, root `CODEOWNERS`, and `docs/CODEOWNERS`.
  */
 
 import { Octokit } from '@octokit/rest';
@@ -49,14 +54,54 @@ export class CodeownersParser {
     return null;
   }
 
+  /**
+   * Build a map from "org/team" → [usernames] by scanning comment lines
+   * matching the convention:  # org/team : user1, user2, ...
+   */
+  private buildTeamMap(content: string): Map<string, string[]> {
+    const teamMap = new Map<string, string[]>();
+
+    for (const rawLine of content.split('\n')) {
+      const line = rawLine.trim();
+      if (!line.startsWith('#')) continue;
+
+      const body = line.slice(1).trim();
+      const colonIdx = body.indexOf(':');
+      if (colonIdx === -1) continue;
+
+      const teamRef = body.slice(0, colonIdx).trim();
+      if (!teamRef.includes('/')) continue;
+
+      const usersStr = body.slice(colonIdx + 1).trim();
+      if (!usersStr) continue;
+
+      const users = usersStr
+        .split(/[,\s]+/)
+        .map(u => u.replace(/^@/, '').trim().toLowerCase())
+        .filter(Boolean);
+
+      if (users.length > 0) {
+        teamMap.set(teamRef.toLowerCase(), users);
+        logger.debug(`CODEOWNERS team mapping: ${teamRef} → ${users.join(', ')}`);
+      }
+    }
+
+    return teamMap;
+  }
+
   private parseContent(content: string, sourceUrl: string): CodeownersEntry[] {
+    const teamMap = this.buildTeamMap(content);
     const userPaths = new Map<string, Set<string>>();
+
+    const addUser = (username: string, pattern: string) => {
+      if (!userPaths.has(username)) userPaths.set(username, new Set());
+      userPaths.get(username)!.add(pattern);
+    };
 
     for (const rawLine of content.split('\n')) {
       const line = rawLine.trim();
       if (!line || line.startsWith('#')) continue;
 
-      // Format: <pattern> @owner1 @owner2 …
       const parts = line.split(/\s+/);
       if (parts.length < 2) continue;
 
@@ -66,13 +111,19 @@ export class CodeownersParser {
         const ref = parts[i];
         if (!ref.startsWith('@')) continue;
 
-        const value = ref.slice(1); // strip leading @
-        // Skip org/team references (contain a slash)
-        if (value.includes('/')) continue;
+        const value = ref.slice(1);
 
-        const username = value.toLowerCase();
-        if (!userPaths.has(username)) userPaths.set(username, new Set());
-        userPaths.get(username)!.add(pattern);
+        if (value.includes('/')) {
+          const resolved = teamMap.get(value.toLowerCase());
+          if (resolved) {
+            for (const username of resolved) {
+              addUser(username, pattern);
+            }
+          }
+          continue;
+        }
+
+        addUser(value.toLowerCase(), pattern);
       }
     }
 

--- a/backend/src/modules/collection/codeowners-parser.ts
+++ b/backend/src/modules/collection/codeowners-parser.ts
@@ -70,7 +70,7 @@ export class CodeownersParser {
       if (colonIdx === -1) continue;
 
       const teamRef = body.slice(0, colonIdx).trim();
-      if (!teamRef.includes('/')) continue;
+      if (!/^[\w.-]+\/[\w.-]+$/.test(teamRef)) continue;
 
       const usersStr = body.slice(colonIdx + 1).trim();
       if (!usersStr) continue;


### PR DESCRIPTION
Some repos (e.g. llama.cpp) list maintainers in CODEOWNERS comment headers because GitHub team visibility is private. The parser now scans for `# org/team : user1, user2` comment lines, builds a team-to-users map, and expands @org/team refs in rule lines using that map. Direct @username refs continue to work as before.