### PR TITLE
rename GGML display name to llama.cpp

### DIFF
--- a/backend/src/shared/config/org-registry.ts
+++ b/backend/src/shared/config/org-registry.ts
@@ -310,7 +310,7 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
 
   // ─── GGML (llama.cpp) ─────────────────────────
   {
-    name: 'GGML',
+    name: 'llama.cpp',
     githubOrg: 'ggml-org',
     governanceModel: 'codeowners',
   },


### PR DESCRIPTION
Most people recognize the project as llama.cpp rather than GGML (the initials of creator Georgi Gerganov). The GitHub org slug ggml-org is unchanged — only the human-readable display name is updated.