### PR TITLE
fix(ci): pin kustomize version to prevent build failures

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -49,7 +49,9 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.REGISTRY_ORG }}/upstream-pulse-frontend:latest
 
       - name: Install kustomize
-        uses: imranismail/setup-kustomize@v2
+        uses: imranismail/setup-kustomize@v3
+        with:
+          kustomize-version: '5.8.1'
 
       - name: Determine target overlay
         run: |


### PR DESCRIPTION
The kustomize repo publishes multiple release types (kyaml, cmd/config, kustomize). The wildcard version (*) resolved to the latest kyaml release which has no binary assets, breaking the build. Pin to v5.8.1 and upgrade setup-kustomize action to v3.