### PR TITLE
chore: rename Llama Stack to ogx (Open GenAI Stack)

### DIFF
--- a/backend/src/shared/config/org-registry.ts
+++ b/backend/src/shared/config/org-registry.ts
@@ -188,10 +188,10 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
     governanceModel: 'codeowners',
   },
 
-  // ─── Llama Stack (moved from meta-llama) ────
+  // ─── ogx (Open GenAI Stack, formerly Llama Stack) ────
   {
-    name: 'Llama Stack',
-    githubOrg: 'llamastack',
+    name: 'ogx',
+    githubOrg: 'ogx-ai',
     strategicParticipation: 'sustaining_participation',
     strategicLeadership: 'sustaining_leadership',
     governanceModel: 'codeowners',

--- a/docs/adding-an-org.md
+++ b/docs/adding-an-org.md
@@ -21,7 +21,7 @@ Before adding an org, confirm its governance format is already supported:
 | **Markdown leadership tables** (steering committee, TSC, maintainers) | Kubeflow, KServe, Argo | `LeadershipCollector.parseLeadershipMarkdown()` |
 | **WGs/SIGs YAML** (chairs + tech leads) | Kubeflow | `LeadershipCollector.fetchWorkingGroupLeadership()` |
 | **OWNERS files** (Kubernetes-style) | Kubeflow, KServe, Kubernetes SIGs, Feast | `GitHubCollector` (governance worker) |
-| **CODEOWNERS** (GitHub-native) | vLLM, Ray, OpenVINO, Meta Llama, Caikit | `CodeownersParser` |
+| **CODEOWNERS** (GitHub-native) | vLLM, Ray, OpenVINO, ogx, Caikit | `CodeownersParser` |
 | **None** | MLflow, Hugging Face, BerriAI | No governance collection |
 
 If the org uses one of these formats, you can add it with config alone. If not, see [Adding a New Parser](#7-adding-a-new-parser-if-needed).

--- a/docs/upstream-projects.md
+++ b/docs/upstream-projects.md
@@ -75,14 +75,14 @@ Feature store for ML pipelines.
 
 ---
 
-### Llama Stack (`llamastack/*`)
+### ogx (`ogx-ai/*`)
 
-Llama Stack framework and Kubernetes operator. Strategically important — 30.5% team share in core repo, 82.5% in k8s operator.
+ogx (Open GenAI Stack, formerly Llama Stack) — unified open-source API server for agentic AI. Strategically important — 30.5% team share in core repo, 82.5% in k8s operator.
 
 | Repo | Description | Status |
 |------|-------------|--------|
-| `llamastack/llama-stack` | Llama Stack framework (core) | **Tracked** |
-| `llamastack/llama-stack-k8s-operator` | Kubernetes operator for Llama Stack | **Tracked** |
+| `ogx-ai/ogx` | ogx framework (core) | **Tracked** |
+| `ogx-ai/ogx-k8s-operator` | Kubernetes operator for ogx | **Tracked** |
 
 **Governance**: Uses CODEOWNERS.
 
@@ -202,7 +202,7 @@ Container tooling ecosystem — Podman, RamaLama, AI Lab Recipes, OLOT. Mixed go
 | `containers/podman` | OCI container management tool | **Tracked** |
 | `containers/ramalama` | Local AI model serving with containers | **Tracked** |
 | `containers/ai-lab-recipes` | AI application recipes for containers | **Tracked** |
-| `containers/ramalama-stack` | Llama Stack provider for RamaLama | **Tracked** |
+| `containers/ramalama-stack` | ogx provider for RamaLama | **Tracked** |
 | `containers/olot` | OCI Layers On Top — append layers to OCI images | **Tracked** |
 
 **Governance**: Leadership from `containers/podman` MAINTAINERS.md (6 Core Maintainers, 5 Maintainers, 10 Reviewers, 3 Community Managers). Podman uses OWNERS (27 approvers, 14 reviewers). RamaLama uses CODEOWNERS (11 owners). Uses `repoGovernanceOverride` for per-repo model selection.
@@ -301,7 +301,7 @@ Additional upstream projects across various organizations.
 | **KServe** | 7 | 7 tracked |
 | **vLLM** | 2 | 2 tracked |
 | **Feast** | 1 | 1 tracked |
-| **Llama Stack** | 2 | 2 tracked |
+| **ogx** | 2 | 2 tracked |
 | **llm-d** | 6 | 6 tracked |
 | **MLflow** | 1 | 1 tracked |
 | **Kubernetes** | 7 | 7 tracked |


### PR DESCRIPTION
Llama Stack was officially renamed to ogx upstream on Apr 25, 2026. GitHub org moved from llamastack to ogx-ai, repos renamed accordingly.

- org-registry: update name, githubOrg to ogx-ai
- docs: update all project references and repo paths

Note: prod database rows (projects, leadership_positions) with the old org/repo values need a manual SQL update