### PR TITLE
chore: update Docling and Kagenti org-registry for proper leadership tracking

### DIFF
--- a/backend/src/shared/config/org-registry.ts
+++ b/backend/src/shared/config/org-registry.ts
@@ -335,13 +335,33 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
     governanceModel: 'codeowners',
   },
 
-  // ─── DocLing ──────────────────────────────────
+  // ─── Docling ──────────────────────────────────
   {
-    name: 'DocLing',
-    githubOrg: 'docling',
+    name: 'Docling',
+    githubOrg: 'docling-project',
     strategicParticipation: 'sustaining_participation',
     strategicLeadership: 'sustaining_leadership',
-    governanceModel: 'codeowners',
+    communityRepo: {
+      repo: 'community',
+      defaultBranch: 'main',
+      leadershipFiles: [
+        {
+          path: 'GOVERNANCE.md',
+          groupName: 'Docling TSC',
+          positionType: 'tsc_member',
+          format: 'bullet_list',
+          sectionHeading: 'TSC member',
+        },
+        {
+          path: 'GOVERNANCE.md',
+          groupName: 'Docling Committers',
+          positionType: 'committer',
+          format: 'bullet_list',
+          sectionHeading: 'Committer',
+        },
+      ],
+    },
+    governanceModel: 'none',
   },
 
   // ─── Agentic AI Foundation ────────────────────
@@ -358,7 +378,22 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
     githubOrg: 'kagenti',
     strategicParticipation: 'increasing_participation',
     strategicLeadership: 'increasing_leadership',
-    governanceModel: 'none',
+    communityRepo: {
+      repo: 'kagenti',
+      defaultBranch: 'main',
+      leadershipFiles: [
+        {
+          path: 'MAINTAINERS.md',
+          groupName: 'Kagenti Maintainers',
+          positionType: 'maintainer',
+        },
+      ],
+    },
+    governanceModel: 'codeowners',
+    repoGovernanceOverride: {
+      'kagenti': 'none',
+      'agent-examples': 'codeowners',
+    },
   },
 
   // ─── Kuadrant ────────────────────

--- a/backend/src/shared/config/org-registry.ts
+++ b/backend/src/shared/config/org-registry.ts
@@ -392,7 +392,6 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
     governanceModel: 'codeowners',
     repoGovernanceOverride: {
       'kagenti': 'none',
-      'agent-examples': 'codeowners',
     },
   },
 


### PR DESCRIPTION
## Summary

- **Docling**: Fix `githubOrg` slug from `docling` to `docling-project` (actual GitHub org), fix `governanceModel` from `codeowners` to `none` (no repos use CODEOWNERS), and add `communityRepo` pointing to `docling-project/community` with leadership files for TSC members (4) and Committers (15) parsed from `GOVERNANCE.md` using `bullet_list` format
- **Kagenti**: Add `communityRepo` pointing to `kagenti/kagenti` with `MAINTAINERS.md` (15 maintainers in standard table format), change `governanceModel` from `none` to `codeowners` (3 of 4 tracked repos have CODEOWNERS), and add `repoGovernanceOverride` for mixed governance (`kagenti` → none, `agent-examples` → codeowners)

## What was wrong

| Org | Issue |
|-----|-------|
| Docling | `githubOrg: 'docling'` pointed to wrong org (actual is `docling-project`) — governance collection was broken |
| Docling | `governanceModel: 'codeowners'` was incorrect — none of the tracked repos have CODEOWNERS files |
| Docling | No `communityRepo` configured — `docling-project/community` has a `GOVERNANCE.md` with TSC and Committer lists |
| Kagenti | `governanceModel: 'none'` was incorrect — `kagenti-operator`, `kagenti-extensions`, and `agent-examples` all have CODEOWNERS |
| Kagenti | No `communityRepo` configured — `kagenti/kagenti` has a `MAINTAINERS.md` with 15 maintainers |

## Verification

- TypeScript compiles clean (`npx tsc --noEmit`)
- No linter errors
- Governance file formats verified against actual repo contents on GitHub

## Test plan

- [ ] Deploy to preprod and trigger leadership refresh for both orgs
- [ ] Verify leadership data appears in overview metrics under `leadership.byOrg`
- [ ] Verify CODEOWNERS parsing works for `kagenti-operator` and `kagenti-extensions`
- [ ] Verify `kagenti/kagenti` repo skips CODEOWNERS (override = none)