### PR TITLE
Promote main to preprod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
       - name: Build and push backend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./backend
           push: true
@@ -40,7 +40,7 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.REGISTRY_ORG }}/upstream-pulse-backend:latest
 
       - name: Build and push frontend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./frontend
           push: true

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.PAT_TOKEN }}
 

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -49,7 +49,9 @@ jobs:
             ${{ env.REGISTRY }}/${{ env.REGISTRY_ORG }}/upstream-pulse-frontend:latest
 
       - name: Install kustomize
-        uses: imranismail/setup-kustomize@v2
+        uses: imranismail/setup-kustomize@v3
+        with:
+          kustomize-version: '5.8.1'
 
       - name: Determine target overlay
         run: |

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -24,7 +24,7 @@ jobs:
         run: echo "IMAGE_TAG=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Log in to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.QUAY_ROBOT_USERNAME }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       NODE_ENV: test
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
         run: npm install
         working-directory: backend
 
+      - name: Audit for critical/high vulnerabilities
+        run: npm audit --audit-level=high
+        working-directory: backend
+
       - name: Type check
         run: npm run type-check
         working-directory: backend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
         run: npm install
         working-directory: backend
 
-      - name: Audit for critical/high vulnerabilities
-        run: npm audit --audit-level=high
+      - name: Audit for critical vulnerabilities
+        run: npm audit --audit-level=critical
         working-directory: backend
 
       - name: Type check
@@ -78,6 +78,10 @@ jobs:
 
       - name: Install dependencies
         run: npm install
+        working-directory: frontend
+
+      - name: Audit for critical vulnerabilities
+        run: npm audit --audit-level=critical
         working-directory: frontend
 
       - name: Type check & build

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Set up Node.js
         if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -293,7 +293,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         if: steps.check-paths.outputs.needs_review == 'true'
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Checkout code
         if: steps.check-paths.outputs.needs_review == 'true' && steps.fork-guard.outputs.is_fork != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -269,7 +269,7 @@ jobs:
 
       - name: Checkout base branch
         if: steps.check-paths.outputs.needs_review == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,11 @@ Thumbs.db
 coverage/
 .nyc_output/
 
-# Misc
+# Secrets
 *.pem
+gcp-sa-key.json
+
+# Misc
 .cache/
 access-stats-*.txt
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,6 +22,8 @@ FROM node:20-alpine
 LABEL maintainer="Upstream Pulse Contributors"
 LABEL description="Upstream Pulse Backend API & Worker"
 
+RUN apk upgrade --no-cache
+
 RUN addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,33 +1,40 @@
 # =============================================================================
 # Backend Dockerfile for Upstream Pulse
-# Builds the Fastify API server and BullMQ worker
+# Multi-stage: build with all deps, run with production deps only
 # =============================================================================
+
+# --- Stage 1: Build ---
+FROM node:20-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json* ./
+RUN npm ci && npm cache clean --force
+
+COPY tsconfig.json ./
+COPY src/ ./src/
+
+RUN npm run build
+
+# --- Stage 2: Production ---
 FROM node:20-alpine
 
 LABEL maintainer="Upstream Pulse Contributors"
 LABEL description="Upstream Pulse Backend API & Worker"
 
-# Create non-root user (OpenShift assigns arbitrary UIDs, but this helps locally)
 RUN addgroup -g 1001 -S appgroup && \
     adduser -u 1001 -S appuser -G appgroup
 
 WORKDIR /app
 
-# Copy dependency manifests and install
 COPY package.json package-lock.json* ./
-RUN npm ci && npm cache clean --force
+RUN npm ci --omit=dev && npm cache clean --force
 
-# Copy source code and config
-COPY tsconfig.json drizzle.config.ts ./
-COPY src/ ./src/
-
-# Compile TypeScript
-RUN npm run build
+COPY --from=builder /app/dist ./dist/
 
 # Ensure the app directory is accessible by arbitrary UIDs (OpenShift requirement)
 RUN chown -R 1001:0 /app && chmod -R g=u /app
 
-# Switch to non-root user
 USER 1001
 
 EXPOSE 3000

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -729,24 +729,30 @@ app.post('/api/admin/team-members/sync', { preHandler: [requireAdmin] }, async (
         deactivated = idsToDeactivate.length;
       }
 
-      // Batch relink orphaned data for newly inserted members
-      for (const m of newlyInserted) {
-        const contribResult = await tx.execute(sql`
+    });
+
+    // Relink orphaned data for newly inserted members (outside transaction
+    // so a null-byte error in one member's metadata doesn't abort the sync)
+    for (const m of newlyInserted) {
+      try {
+        const contribResult = await db.execute(sql`
           UPDATE contributions SET team_member_id = ${m.id}
           WHERE team_member_id IS NULL
             AND LOWER((metadata #>> '{}')::jsonb->>'author') = LOWER(${m.githubUsername})
         `) as unknown as { rowCount?: number };
-        const msResult = await tx.execute(sql`
+        const msResult = await db.execute(sql`
           UPDATE maintainer_status SET team_member_id = ${m.id}
           WHERE team_member_id IS NULL AND LOWER(github_username) = LOWER(${m.githubUsername})
         `) as unknown as { rowCount?: number };
-        const lpResult = await tx.execute(sql`
+        const lpResult = await db.execute(sql`
           UPDATE leadership_positions SET team_member_id = ${m.id}
           WHERE team_member_id IS NULL AND LOWER(github_username) = LOWER(${m.githubUsername})
         `) as unknown as { rowCount?: number };
         totalRelinked += (contribResult.rowCount ?? 0) + (msResult.rowCount ?? 0) + (lpResult.rowCount ?? 0);
+      } catch (relinkError) {
+        logger.warn(`Bulk sync: relink failed for @${m.githubUsername} (non-fatal)`, { error: relinkError });
       }
-    });
+    }
 
     // Queue governance + leadership refresh if new members were added (outside transaction)
     if (inserted > 0 || totalRelinked > 0) {

--- a/backend/src/modules/collection/codeowners-parser.ts
+++ b/backend/src/modules/collection/codeowners-parser.ts
@@ -94,8 +94,9 @@ export class CodeownersParser {
     const userPaths = new Map<string, Set<string>>();
 
     const addUser = (username: string, pattern: string) => {
-      if (!userPaths.has(username)) userPaths.set(username, new Set());
-      userPaths.get(username)!.add(pattern);
+      const paths = userPaths.get(username) ?? new Set<string>();
+      paths.add(pattern);
+      userPaths.set(username, paths);
     };
 
     for (const rawLine of content.split('\n')) {

--- a/backend/src/modules/collection/codeowners-parser.ts
+++ b/backend/src/modules/collection/codeowners-parser.ts
@@ -2,10 +2,15 @@
  * CODEOWNERS Parser
  *
  * Parses GitHub-native CODEOWNERS files to extract per-user maintainer entries.
- * Only @username references are captured — @org/team references are skipped
- * because resolving team membership requires `read:org` scope on external orgs.
  *
- * Checks `.github/CODEOWNERS` first, then root `CODEOWNERS`.
+ * Handles two owner formats:
+ *   1. @username — captured directly
+ *   2. @org/team — resolved via comment headers when the repo embeds a
+ *      team-member mapping in comments (e.g. `# org/team : user1, user2`).
+ *      This covers repos where GitHub team visibility is private and
+ *      maintainers are listed in comments by convention.
+ *
+ * Checks `.github/CODEOWNERS`, root `CODEOWNERS`, and `docs/CODEOWNERS`.
  */
 
 import { Octokit } from '@octokit/rest';
@@ -49,14 +54,54 @@ export class CodeownersParser {
     return null;
   }
 
+  /**
+   * Build a map from "org/team" → [usernames] by scanning comment lines
+   * matching the convention:  # org/team : user1, user2, ...
+   */
+  private buildTeamMap(content: string): Map<string, string[]> {
+    const teamMap = new Map<string, string[]>();
+
+    for (const rawLine of content.split('\n')) {
+      const line = rawLine.trim();
+      if (!line.startsWith('#')) continue;
+
+      const body = line.slice(1).trim();
+      const colonIdx = body.indexOf(':');
+      if (colonIdx === -1) continue;
+
+      const teamRef = body.slice(0, colonIdx).trim();
+      if (!teamRef.includes('/')) continue;
+
+      const usersStr = body.slice(colonIdx + 1).trim();
+      if (!usersStr) continue;
+
+      const users = usersStr
+        .split(/[,\s]+/)
+        .map(u => u.replace(/^@/, '').trim().toLowerCase())
+        .filter(Boolean);
+
+      if (users.length > 0) {
+        teamMap.set(teamRef.toLowerCase(), users);
+        logger.debug(`CODEOWNERS team mapping: ${teamRef} → ${users.join(', ')}`);
+      }
+    }
+
+    return teamMap;
+  }
+
   private parseContent(content: string, sourceUrl: string): CodeownersEntry[] {
+    const teamMap = this.buildTeamMap(content);
     const userPaths = new Map<string, Set<string>>();
+
+    const addUser = (username: string, pattern: string) => {
+      if (!userPaths.has(username)) userPaths.set(username, new Set());
+      userPaths.get(username)!.add(pattern);
+    };
 
     for (const rawLine of content.split('\n')) {
       const line = rawLine.trim();
       if (!line || line.startsWith('#')) continue;
 
-      // Format: <pattern> @owner1 @owner2 …
       const parts = line.split(/\s+/);
       if (parts.length < 2) continue;
 
@@ -66,13 +111,19 @@ export class CodeownersParser {
         const ref = parts[i];
         if (!ref.startsWith('@')) continue;
 
-        const value = ref.slice(1); // strip leading @
-        // Skip org/team references (contain a slash)
-        if (value.includes('/')) continue;
+        const value = ref.slice(1);
 
-        const username = value.toLowerCase();
-        if (!userPaths.has(username)) userPaths.set(username, new Set());
-        userPaths.get(username)!.add(pattern);
+        if (value.includes('/')) {
+          const resolved = teamMap.get(value.toLowerCase());
+          if (resolved) {
+            for (const username of resolved) {
+              addUser(username, pattern);
+            }
+          }
+          continue;
+        }
+
+        addUser(value.toLowerCase(), pattern);
       }
     }
 

--- a/backend/src/modules/collection/codeowners-parser.ts
+++ b/backend/src/modules/collection/codeowners-parser.ts
@@ -70,7 +70,7 @@ export class CodeownersParser {
       if (colonIdx === -1) continue;
 
       const teamRef = body.slice(0, colonIdx).trim();
-      if (!teamRef.includes('/')) continue;
+      if (!/^[\w.-]+\/[\w.-]+$/.test(teamRef)) continue;
 
       const usersStr = body.slice(colonIdx + 1).trim();
       if (!usersStr) continue;

--- a/backend/src/modules/collection/leadership-collector.ts
+++ b/backend/src/modules/collection/leadership-collector.ts
@@ -406,7 +406,10 @@ export class LeadershipCollector {
   // ── Bullet-list parser ─────────────────────────────────────────
 
   /**
-   * Parse a markdown file with `- [Name](https://github.com/username)` bullet entries.
+   * Parse a markdown file with bullet-list leadership entries.
+   * Supports two formats:
+   *   - `- [Name](https://github.com/username)`
+   *   - `- Name [@username](https://github.com/username)`
    * Optionally scoped to a specific section via `fileCfg.sectionHeading`.
    */
   private async parseBulletListFile(fileCfg: LeadershipFileConfig): Promise<LeadershipPosition[]> {
@@ -430,9 +433,14 @@ export class LeadershipCollector {
         lines = this.extractSection(lines, fileCfg.sectionHeading);
       }
 
-      const linkPattern = /^[-*]\s+\[([^\]]+)\]\(https?:\/\/github\.com\/([^/)]+)\/?[^)]*\)/;
+      // Format 1: - [Name](https://github.com/username)
+      const directLinkPattern = /^[-*]\s+\[([^\]]+)\]\(https?:\/\/github\.com\/([^/)]+)\/?[^)]*\)/;
+      // Format 2: - Name [@username](https://github.com/username)
+      const namedLinkPattern = /^[-*]\s+(.+?)\s+\[@?[^\]]+\]\(https?:\/\/github\.com\/([^/)]+)\/?[^)]*\)/;
+
       for (const line of lines) {
-        const match = line.trim().match(linkPattern);
+        const trimmed = line.trim();
+        const match = trimmed.match(directLinkPattern) || trimmed.match(namedLinkPattern);
         if (!match) continue;
 
         positions.push({

--- a/backend/src/shared/config/org-registry.ts
+++ b/backend/src/shared/config/org-registry.ts
@@ -335,13 +335,33 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
     governanceModel: 'codeowners',
   },
 
-  // ─── DocLing ──────────────────────────────────
+  // ─── Docling ──────────────────────────────────
   {
-    name: 'DocLing',
-    githubOrg: 'docling',
+    name: 'Docling',
+    githubOrg: 'docling-project',
     strategicParticipation: 'sustaining_participation',
     strategicLeadership: 'sustaining_leadership',
-    governanceModel: 'codeowners',
+    communityRepo: {
+      repo: 'community',
+      defaultBranch: 'main',
+      leadershipFiles: [
+        {
+          path: 'GOVERNANCE.md',
+          groupName: 'Docling TSC',
+          positionType: 'tsc_member',
+          format: 'bullet_list',
+          sectionHeading: 'TSC member',
+        },
+        {
+          path: 'GOVERNANCE.md',
+          groupName: 'Docling Committers',
+          positionType: 'committer',
+          format: 'bullet_list',
+          sectionHeading: 'Committer',
+        },
+      ],
+    },
+    governanceModel: 'none',
   },
 
   // ─── Agentic AI Foundation ────────────────────
@@ -358,7 +378,22 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
     githubOrg: 'kagenti',
     strategicParticipation: 'increasing_participation',
     strategicLeadership: 'increasing_leadership',
-    governanceModel: 'none',
+    communityRepo: {
+      repo: 'kagenti',
+      defaultBranch: 'main',
+      leadershipFiles: [
+        {
+          path: 'MAINTAINERS.md',
+          groupName: 'Kagenti Maintainers',
+          positionType: 'maintainer',
+        },
+      ],
+    },
+    governanceModel: 'codeowners',
+    repoGovernanceOverride: {
+      'kagenti': 'none',
+      'agent-examples': 'codeowners',
+    },
   },
 
   // ─── Kuadrant ────────────────────

--- a/backend/src/shared/config/org-registry.ts
+++ b/backend/src/shared/config/org-registry.ts
@@ -310,7 +310,7 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
 
   // ─── GGML (llama.cpp) ─────────────────────────
   {
-    name: 'GGML',
+    name: 'llama.cpp',
     githubOrg: 'ggml-org',
     governanceModel: 'codeowners',
   },

--- a/backend/src/shared/config/org-registry.ts
+++ b/backend/src/shared/config/org-registry.ts
@@ -360,6 +360,25 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
     strategicLeadership: 'increasing_leadership',
     governanceModel: 'none',
   },
+
+  // ─── Kuadrant ────────────────────
+  {
+    name: 'Kuadrant',
+    githubOrg: 'Kuadrant',
+    communityRepo: {
+      repo: 'kuadrant-operator',
+      defaultBranch: 'main',
+      leadershipFiles: [
+        {
+          path: 'MAINTAINERS.md',
+          groupName: 'Kuadrant',
+          positionType: 'maintainer',
+          format: 'bullet_list',
+        },
+      ],
+    },
+    governanceModel: 'none',
+  },
 ];
 
 // ── Lookup helpers ──────────────────────────────────────────────────

--- a/backend/src/shared/config/org-registry.ts
+++ b/backend/src/shared/config/org-registry.ts
@@ -188,10 +188,10 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
     governanceModel: 'codeowners',
   },
 
-  // ─── Llama Stack (moved from meta-llama) ────
+  // ─── ogx (Open GenAI Stack, formerly Llama Stack) ────
   {
-    name: 'Llama Stack',
-    githubOrg: 'llamastack',
+    name: 'ogx',
+    githubOrg: 'ogx-ai',
     strategicParticipation: 'sustaining_participation',
     strategicLeadership: 'sustaining_leadership',
     governanceModel: 'codeowners',

--- a/backend/src/shared/config/org-registry.ts
+++ b/backend/src/shared/config/org-registry.ts
@@ -392,7 +392,6 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
     governanceModel: 'codeowners',
     repoGovernanceOverride: {
       'kagenti': 'none',
-      'agent-examples': 'codeowners',
     },
   },
 

--- a/deploy/openshift/base/backup.Dockerfile
+++ b/deploy/openshift/base/backup.Dockerfile
@@ -1,2 +1,2 @@
 FROM postgres:16-alpine
-RUN apk add --no-cache aws-cli
+RUN apk upgrade --no-cache && apk add --no-cache aws-cli

--- a/deploy/openshift/overlays/preprod/configmap-patch.yaml
+++ b/deploy/openshift/overlays/preprod/configmap-patch.yaml
@@ -4,5 +4,5 @@ metadata:
   name: upstream-pulse-config
   namespace: upstream-pulse
 data:
-  ADMIN_USERS: "admin,roster-sync-service"
+  ADMIN_USERS: "admin,roster-sync-service,dipgupta"
   GITHUB_TEAM_ORG: ""

--- a/deploy/openshift/overlays/prod/configmap-patch.yaml
+++ b/deploy/openshift/overlays/prod/configmap-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: upstream-pulse-config
+  namespace: upstream-pulse
+data:
+  ADMIN_USERS: "admin,roster-sync-service"
+  GITHUB_TEAM_ORG: ""

--- a/deploy/openshift/overlays/prod/configmap-patch.yaml
+++ b/deploy/openshift/overlays/prod/configmap-patch.yaml
@@ -4,5 +4,5 @@ metadata:
   name: upstream-pulse-config
   namespace: upstream-pulse
 data:
-  ADMIN_USERS: "admin,roster-sync-service"
+  ADMIN_USERS: "admin,roster-sync-service,dipgupta"
   GITHUB_TEAM_ORG: ""

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: 2eb0dd2
+  newTag: e601ceb
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: 2eb0dd2
+  newTag: e601ceb

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -17,6 +17,6 @@ resources:
 - postgres-restore-test-cronjob.yaml
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: 68f8780
+  newTag: 2bccd51
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: 68f8780
+  newTag: 2bccd51

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: ad55fab
+  newTag: 84bb405
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: ad55fab
+  newTag: 84bb405

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: d3c79bb
+  newTag: 8fee56b
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: d3c79bb
+  newTag: 8fee56b

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: d47123a
+  newTag: d3c79bb
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: d47123a
+  newTag: d3c79bb

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -17,6 +17,6 @@ resources:
 - postgres-restore-test-cronjob.yaml
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: 2bccd51
+  newTag: 63beb96
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: 2bccd51
+  newTag: 63beb96

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -15,6 +15,10 @@ resources:
 - postgres-backup-cronjob.yaml
 - postgres-backup-monitor-cronjob.yaml
 - postgres-restore-test-cronjob.yaml
+
+patches:
+- path: configmap-patch.yaml
+
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
   newTag: 2bccd51

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: 63beb96
+  newTag: 247d6da
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: 63beb96
+  newTag: 247d6da

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: 247d6da
+  newTag: d47123a
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: 247d6da
+  newTag: d47123a

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: 8fee56b
+  newTag: bba9ac0
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: 8fee56b
+  newTag: bba9ac0

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: bba9ac0
+  newTag: ad55fab
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: bba9ac0
+  newTag: ad55fab

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: 84bb405
+  newTag: 2eb0dd2
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: 84bb405
+  newTag: 2eb0dd2

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: e601ceb
+  newTag: 27a450d
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: e601ceb
+  newTag: 27a450d

--- a/docs/adding-an-org.md
+++ b/docs/adding-an-org.md
@@ -21,7 +21,7 @@ Before adding an org, confirm its governance format is already supported:
 | **Markdown leadership tables** (steering committee, TSC, maintainers) | Kubeflow, KServe, Argo | `LeadershipCollector.parseLeadershipMarkdown()` |
 | **WGs/SIGs YAML** (chairs + tech leads) | Kubeflow | `LeadershipCollector.fetchWorkingGroupLeadership()` |
 | **OWNERS files** (Kubernetes-style) | Kubeflow, KServe, Kubernetes SIGs, Feast | `GitHubCollector` (governance worker) |
-| **CODEOWNERS** (GitHub-native) | vLLM, Ray, OpenVINO, Meta Llama, Caikit | `CodeownersParser` |
+| **CODEOWNERS** (GitHub-native) | vLLM, Ray, OpenVINO, ogx, Caikit | `CodeownersParser` |
 | **None** | MLflow, Hugging Face, BerriAI | No governance collection |
 
 If the org uses one of these formats, you can add it with config alone. If not, see [Adding a New Parser](#7-adding-a-new-parser-if-needed).

--- a/docs/upstream-projects.md
+++ b/docs/upstream-projects.md
@@ -2,7 +2,7 @@
 
 Upstream Pulse provides contribution tracking and governance insights for the following upstream open-source organizations and projects. This document lists what is currently supported and what is planned next, organized by upstream organization.
 
-**Last updated**: 2026-04-07
+**Last updated**: 2026-04-15
 
 ---
 
@@ -233,6 +233,20 @@ Meta's open-source deep learning framework. Tracking for emerging team contribut
 
 ---
 
+### Kuadrant (`Kuadrant/*`)
+
+Gateway policies for Kubernetes — API management, rate limiting, DNS, and auth.
+
+| Repo | Description | Status |
+|------|-------------|--------|
+| `Kuadrant/authorino` | Kubernetes-native auth service | **Tracked** |
+| `Kuadrant/limitador` | Rate limiting service | **Tracked** |
+| `Kuadrant/wasm-shim` | Wasm extension for Envoy | **Tracked** |
+
+**Governance**: Leadership from `kuadrant-operator/MAINTAINERS.md` (13 org-level maintainers, bullet-list format). Tracked repos have no OWNERS/CODEOWNERS.
+
+---
+
 ## Planned Additions
 
 ### OpenVINO (`openvinotoolkit/*`)
@@ -298,10 +312,11 @@ Additional upstream projects across various organizations.
 | **Containers** | 5 | 5 tracked |
 | **GGML** | 1 | 1 tracked |
 | **PyTorch** | 1 | 1 tracked |
+| **Kuadrant** | 3 | 3 tracked |
 | **OpenVINO** | 4 | Planned |
 | **Caikit** | 3 | Planned |
 | **Individual repos** | 6 | Planned |
-| **Total** | **73** | 58 tracked, 15 planned |
+| **Total** | **76** | 61 tracked, 15 planned |
 
 ---
 

--- a/docs/upstream-projects.md
+++ b/docs/upstream-projects.md
@@ -75,14 +75,14 @@ Feature store for ML pipelines.
 
 ---
 
-### Llama Stack (`llamastack/*`)
+### ogx (`ogx-ai/*`)
 
-Llama Stack framework and Kubernetes operator. Strategically important — 30.5% team share in core repo, 82.5% in k8s operator.
+ogx (Open GenAI Stack, formerly Llama Stack) — unified open-source API server for agentic AI. Strategically important — 30.5% team share in core repo, 82.5% in k8s operator.
 
 | Repo | Description | Status |
 |------|-------------|--------|
-| `llamastack/llama-stack` | Llama Stack framework (core) | **Tracked** |
-| `llamastack/llama-stack-k8s-operator` | Kubernetes operator for Llama Stack | **Tracked** |
+| `ogx-ai/ogx` | ogx framework (core) | **Tracked** |
+| `ogx-ai/ogx-k8s-operator` | Kubernetes operator for ogx | **Tracked** |
 
 **Governance**: Uses CODEOWNERS.
 
@@ -202,7 +202,7 @@ Container tooling ecosystem — Podman, RamaLama, AI Lab Recipes, OLOT. Mixed go
 | `containers/podman` | OCI container management tool | **Tracked** |
 | `containers/ramalama` | Local AI model serving with containers | **Tracked** |
 | `containers/ai-lab-recipes` | AI application recipes for containers | **Tracked** |
-| `containers/ramalama-stack` | Llama Stack provider for RamaLama | **Tracked** |
+| `containers/ramalama-stack` | ogx provider for RamaLama | **Tracked** |
 | `containers/olot` | OCI Layers On Top — append layers to OCI images | **Tracked** |
 
 **Governance**: Leadership from `containers/podman` MAINTAINERS.md (6 Core Maintainers, 5 Maintainers, 10 Reviewers, 3 Community Managers). Podman uses OWNERS (27 approvers, 14 reviewers). RamaLama uses CODEOWNERS (11 owners). Uses `repoGovernanceOverride` for per-repo model selection.
@@ -301,7 +301,7 @@ Additional upstream projects across various organizations.
 | **KServe** | 7 | 7 tracked |
 | **vLLM** | 2 | 2 tracked |
 | **Feast** | 1 | 1 tracked |
-| **Llama Stack** | 2 | 2 tracked |
+| **ogx** | 2 | 2 tracked |
 | **llm-d** | 6 | 6 tracked |
 | **MLflow** | 1 | 1 tracked |
 | **Kubernetes** | 7 | 7 tracked |

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -23,7 +23,8 @@ FROM nginx:1.27-alpine
 LABEL maintainer="Upstream Pulse Contributors"
 LABEL description="Upstream Pulse Frontend Dashboard"
 
-# Remove default nginx config
+RUN apk upgrade --no-cache
+
 RUN rm /etc/nginx/conf.d/default.conf
 
 # Copy custom nginx config

--- a/frontend/src/pages/SystemStatus.tsx
+++ b/frontend/src/pages/SystemStatus.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import { useAuth } from '../context/AuthContext';
 import {
   Activity,
   CheckCircle2,
@@ -18,6 +19,9 @@ import {
   Server,
   ChevronDown,
   Tag,
+  Play,
+  Loader2,
+  Check,
 } from 'lucide-react';
 import { PageLoading } from '../components/common/PageLoading';
 import { PageError } from '../components/common/PageError';
@@ -210,10 +214,50 @@ function QueueBar({ stats }: { stats: QueueStats }) {
   );
 }
 
-function WorkerCard({ worker }: { worker: WorkerInfo }) {
+const runNowEndpoints: Record<string, string> = {
+  'governance-refresh': '/api/governance/refresh',
+  'leadership-refresh': '/api/leadership/refresh',
+};
+
+type RunNowState = 'idle' | 'loading' | 'success' | 'error';
+
+function WorkerCard({
+  worker,
+  isAdmin,
+  onRunNowComplete,
+}: {
+  worker: WorkerInfo;
+  isAdmin: boolean;
+  onRunNowComplete?: () => void;
+}) {
   const hc = healthConfig[worker.health];
   const Icon = workerIcons[worker.id] || Activity;
   const isActive = worker.queue.active > 0;
+  const endpoint = runNowEndpoints[worker.id];
+  const canRunNow = isAdmin && !!endpoint;
+  const isBusy = worker.queue.active > 0 || worker.queue.waiting > 0;
+  const [runState, setRunState] = useState<RunNowState>('idle');
+  const [errorMsg, setErrorMsg] = useState('');
+  const resetTimer = useRef<ReturnType<typeof setTimeout>>();
+
+  const handleRunNow = useCallback(async () => {
+    if (!endpoint) return;
+    clearTimeout(resetTimer.current);
+    setRunState('loading');
+    setErrorMsg('');
+    try {
+      const res = await apiFetch(endpoint, { method: 'POST' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setRunState('success');
+      onRunNowComplete?.();
+      resetTimer.current = setTimeout(() => setRunState('idle'), 2500);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Unknown error';
+      setErrorMsg(msg);
+      setRunState('error');
+      resetTimer.current = setTimeout(() => setRunState('idle'), 3000);
+    }
+  }, [endpoint, onRunNowComplete]);
 
   return (
     <div className={`
@@ -263,9 +307,34 @@ function WorkerCard({ worker }: { worker: WorkerInfo }) {
         </div>
       </div>
 
-      <div className="mt-3 flex items-center gap-1.5">
-        <Clock className="w-3 h-3 text-gray-400" />
-        <span className="text-xs font-mono text-gray-400">{worker.schedule.human}</span>
+      <div className="mt-3 flex items-center justify-between">
+        <div className="flex items-center gap-1.5">
+          <Clock className="w-3 h-3 text-gray-400" />
+          <span className="text-xs font-mono text-gray-400">{worker.schedule.human}</span>
+        </div>
+        {canRunNow && (
+          <button
+            onClick={handleRunNow}
+            disabled={isBusy || runState === 'loading'}
+            title={runState === 'error' ? `Failed: ${errorMsg}` : isBusy ? 'A job is already running or queued' : 'Queue a manual refresh now'}
+            className={`
+              flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-xs font-medium transition-all
+              ${runState === 'success'
+                ? 'bg-emerald-50 text-emerald-600 border border-emerald-200'
+                : runState === 'error'
+                  ? 'bg-red-50 text-red-600 border border-red-200'
+                  : isBusy || runState === 'loading'
+                    ? 'bg-gray-50 text-gray-400 border border-gray-200 cursor-not-allowed'
+                    : 'bg-indigo-50 text-indigo-600 border border-indigo-200 hover:bg-indigo-100 hover:border-indigo-300'}
+            `}
+          >
+            {runState === 'loading' && <Loader2 className="w-3 h-3 animate-spin" />}
+            {runState === 'success' && <Check className="w-3 h-3" />}
+            {runState === 'error' && <AlertTriangle className="w-3 h-3" />}
+            {runState === 'idle' && (isBusy ? <Loader2 className="w-3 h-3" /> : <Play className="w-3 h-3" />)}
+            {runState === 'loading' ? 'Queuing...' : runState === 'success' ? 'Queued' : runState === 'error' ? 'Failed' : isBusy ? 'In Progress' : 'Run Now'}
+          </button>
+        )}
       </div>
     </div>
   );
@@ -354,13 +423,15 @@ function JobRow({ job, isExpanded, onToggle }: { job: JobRecord; isExpanded: boo
 }
 
 export default function SystemStatus() {
+  const { isAdmin } = useAuth();
   const [expandedJobId, setExpandedJobId] = useState<string | null>(null);
-  const { data, isLoading, error, refetch, isFetching } = useQuery({
+  const { data, isLoading, error, refetch, isFetching } = useQuery<SystemStatusData>({
     queryKey: ['system-status'],
     queryFn: fetchSystemStatus,
     refetchInterval: 15000,
     placeholderData: (prev) => prev,
   });
+  const handleRunNowComplete = useCallback(() => refetch(), [refetch]);
 
   if (isLoading) return <PageLoading message="Initializing system diagnostics..." />;
 
@@ -452,7 +523,12 @@ export default function SystemStatus() {
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               {data.workers.map((worker) => (
-                <WorkerCard key={worker.id} worker={worker} />
+                <WorkerCard
+                  key={worker.id}
+                  worker={worker}
+                  isAdmin={isAdmin}
+                  onRunNowComplete={handleRunNowComplete}
+                />
               ))}
             </div>
           )}


### PR DESCRIPTION
## Summary

- Promotes current main to preprod, including 20 commits since last sync
- Key changes: admin Run Now buttons, org-registry updates (Docling, Kagenti, Llama Stack rename), system status page enhancements, dependabot bumps for CI actions
- Lockfile already carries patched versions of lodash (4.18.1), hono (4.12.17), flatted (3.4.2) — rebuilding from this resolves the npm-level CVEs from the AMBC-001 vulnerability report

## Test plan

- [ ] Verify Argo CD syncs preprod overlay successfully after merge
- [ ] Confirm backend and frontend pods start without errors
- [ ] Spot-check admin Run Now buttons on preprod
- [ ] Validate org-registry changes reflect correct Docling/Kagenti/OGX config