### PR TITLE
Promote main to preprod (AMBC-001 fixes)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,6 +33,7 @@ COPY package.json package-lock.json* ./
 RUN npm ci --omit=dev && npm cache clean --force
 
 COPY --from=builder /app/dist ./dist/
+COPY src/shared/database/migrations ./dist/shared/database/migrations/
 
 # Ensure the app directory is accessible by arbitrary UIDs (OpenShift requirement)
 RUN chown -R 1001:0 /app && chmod -R g=u /app

--- a/deploy/openshift/base/backend-deployment.yaml
+++ b/deploy/openshift/base/backend-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         - name: db-migrate
           image: quay.io/org-pulse/upstream-pulse-backend:latest
           imagePullPolicy: Always
-          command: ["/bin/sh", "-c", "npx drizzle-kit push:pg --schema ./src/shared/database/schema.ts --driver pg --connectionString \"$DATABASE_URL\""]
+          command: ["node", "dist/shared/database/run-migrate.js"]
           env:
             - name: HOME
               value: /tmp

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: 27a450d
+  newTag: 0e4a1ab
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: 27a450d
+  newTag: 0e4a1ab


### PR DESCRIPTION
## Summary

- Promotes current main to preprod, including the AMBC-001 vulnerability fixes that landed after the previous promotion (#57)
- Key changes since last promotion:
  - Multi-stage backend Dockerfile (devDeps excluded from production image)
  - `apk upgrade` in backend, frontend, and backup Dockerfiles
  - `npm audit --audit-level=critical` in CI for both backend and frontend
  - Compiled migration runner replacing `npx drizzle-kit push:pg`

## Test plan

- [ ] Verify build-and-push workflow completes for preprod
- [ ] Confirm all pods start without errors (especially backend db-migrate init container)
- [ ] Spot-check application functionality on preprod