### PR TITLE
fix: copy migration files from builder stage instead of build context

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,7 +33,7 @@ COPY package.json package-lock.json* ./
 RUN npm ci --omit=dev && npm cache clean --force
 
 COPY --from=builder /app/dist ./dist/
-COPY src/shared/database/migrations ./dist/shared/database/migrations/
+COPY --from=builder /app/src/shared/database/migrations ./dist/shared/database/migrations/
 
 # Ensure the app directory is accessible by arbitrary UIDs (OpenShift requirement)
 RUN chown -R 1001:0 /app && chmod -R g=u /app


### PR DESCRIPTION
## Summary

- Fixes db-migrate init container crash: `Can't find meta/_journal.json file`
- Changes `COPY src/shared/database/migrations` to `COPY --from=builder` so migration SQL files come from the builder stage (which already has them verified) instead of the build context directly

## Test plan

- [ ] CI passes
- [ ] After merge, verify the backend pod's db-migrate init container succeeds on both prod and preprod