### PR TITLE
Promote main to preprod (migration fix)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,7 +33,7 @@ COPY package.json package-lock.json* ./
 RUN npm ci --omit=dev && npm cache clean --force
 
 COPY --from=builder /app/dist ./dist/
-COPY src/shared/database/migrations ./dist/shared/database/migrations/
+COPY --from=builder /app/src/shared/database/migrations ./dist/shared/database/migrations/
 
 # Ensure the app directory is accessible by arbitrary UIDs (OpenShift requirement)
 RUN chown -R 1001:0 /app && chmod -R g=u /app

--- a/deploy/openshift/overlays/prod/kustomization.yaml
+++ b/deploy/openshift/overlays/prod/kustomization.yaml
@@ -21,6 +21,6 @@ patches:
 
 images:
 - name: quay.io/org-pulse/upstream-pulse-backend
-  newTag: 0e4a1ab
+  newTag: 2a1a241
 - name: quay.io/org-pulse/upstream-pulse-frontend
-  newTag: 0e4a1ab
+  newTag: 2a1a241


### PR DESCRIPTION
## Summary

- Promotes the migration files COPY fix (PR #59) to preprod
- Fixes the db-migrate init container crash (`Can't find meta/_journal.json`) that is currently blocking the new backend deployment on preprod

## Test plan

- [ ] Verify build-and-push workflow completes for preprod
- [ ] Confirm backend pod's db-migrate init container succeeds
- [ ] All pods Running and Ready