### PR TITLE
Update strategic classifications: add OpenClaw, OpenCode, NVIDIA; remove Kagenti

### DIFF
--- a/backend/src/shared/config/org-registry.ts
+++ b/backend/src/shared/config/org-registry.ts
@@ -298,13 +298,33 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
     governanceModel: 'none',
   },
   {
-    name: 'NVIDIA',
+    name: 'OpenShell',
     githubOrg: 'NVIDIA',
+    strategicParticipation: 'increasing_participation',
+    strategicLeadership: 'increasing_leadership',
     governanceModel: 'codeowners',
   },
   {
     name: 'Seldon',
     githubOrg: 'SeldonIO',
+    governanceModel: 'none',
+  },
+
+  // ─── OpenClaw ────────────────────────────────
+  {
+    name: 'OpenClaw',
+    githubOrg: 'openclaw',
+    strategicParticipation: 'increasing_participation',
+    strategicLeadership: 'increasing_leadership',
+    governanceModel: 'codeowners',
+  },
+
+  // ─── OpenCode ────────────────────────────────
+  {
+    name: 'OpenCode',
+    githubOrg: 'anomalyco',
+    strategicParticipation: 'increasing_participation',
+    strategicLeadership: 'increasing_leadership',
     governanceModel: 'none',
   },
 
@@ -376,8 +396,6 @@ export const ORG_REGISTRY: UpstreamOrgConfig[] = [
   {
     name: 'Kagenti',
     githubOrg: 'kagenti',
-    strategicParticipation: 'increasing_participation',
-    strategicLeadership: 'increasing_leadership',
     communityRepo: {
       repo: 'kagenti',
       defaultBranch: 'main',


### PR DESCRIPTION
## Summary

- **NVIDIA** (OpenShell): marked as increasing participation + leadership
- **OpenClaw** (`openclaw`): added as new org with increasing participation + leadership
- **OpenCode** (`opencode-ai`): added as new org with increasing participation + leadership
- **Kagenti**: removed strategic classification (org entry preserved for tracking)

Reflects the latest strategic focus shift discussed by Steven Huels.

## Test plan

- [ ] Verify Strategy page shows NVIDIA, OpenClaw, and OpenCode in the Increasing tier
- [ ] Verify Kagenti no longer appears on the Strategy page
- [ ] Verify Dashboard strategic communities card reflects updated counts
- [ ] Verify Portfolio page sorts updated orgs correctly by strategic importance